### PR TITLE
Make Quark compile with latest rustc and rdma check in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+build/

--- a/qkernel/Cargo.lock
+++ b/qkernel/Cargo.lock
@@ -4,12 +4,6 @@ version = 3
 
 [[package]]
 name = "bit_field"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
-
-[[package]]
-name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
@@ -87,7 +81,7 @@ dependencies = [
 name = "qkernel"
 version = "0.6.0"
 dependencies = [
- "bit_field 0.10.1",
+ "bit_field",
  "bitflags",
  "buddy_system_allocator",
  "cache-padded",
@@ -282,18 +276,18 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c146cbc47471e076987378c159a7aa8fa434680c6fbddca59fe6f40f1591c819"
 dependencies = [
- "bit_field 0.10.1",
+ "bit_field",
  "bitflags",
  "raw-cpuid",
 ]
 
 [[package]]
 name = "x86_64"
-version = "0.14.3"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c54a17492391c594753ce2a180142bec7ad2876543565c2a08aa11cddef251"
+checksum = "fb611915c917c6296d11e23f71ff1ecfe49c5766daba92cd3df52df6b58285b6"
 dependencies = [
- "bit_field 0.9.0",
+ "bit_field",
  "bitflags",
  "volatile",
 ]

--- a/qkernel/Cargo.toml
+++ b/qkernel/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 bit_field = "0.10.1"
 bitflags = "1.2.1"
 rusty-asm = "0.2.1"
-x86_64 = "0.14.3"
+x86_64 = "0.14.7"
 
 #linked_list_allocator = "0.8.6"
 buddy_system_allocator = "0.8.0"

--- a/qvisor/Cargo.lock
+++ b/qvisor/Cargo.lock
@@ -85,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 
 [[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,7 +667,7 @@ dependencies = [
 name = "quark"
 version = "0.6.0"
 dependencies = [
- "bit_field",
+ "bit_field 0.9.0",
  "bitflags",
  "buddy_system_allocator",
  "byteorder",
@@ -1271,11 +1277,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x86_64"
-version = "0.14.3"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c54a17492391c594753ce2a180142bec7ad2876543565c2a08aa11cddef251"
+checksum = "fb611915c917c6296d11e23f71ff1ecfe49c5766daba92cd3df52df6b58285b6"
 dependencies = [
- "bit_field",
+ "bit_field 0.10.1",
  "bitflags",
  "volatile",
 ]

--- a/qvisor/Cargo.toml
+++ b/qvisor/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.94"
 kvm-bindings = "0.5.0"
 kvm-ioctls = "0.10.0"
 xmas-elf = { git = "https://github.com/gz/xmas-elf.git" }
-x86_64 = "0.14.3"
+x86_64 = "0.14.7"
 memmap = "0.7.0"
 ux = "0.1.2"
 byteorder = "1.3.2"
@@ -48,7 +48,7 @@ num_cpus = "1.13.0"
 buddy_system_allocator = "0.8.0"
 core_affinity = "0.5.10"
 cache-padded = "1.1.1"
-rdmaffi = { path = "/home/brad/rust/RDMARust/rdma-sys", package = "rdma-sys", version = "0.1.0" }
+rdmaffi = { path = "../../RDMARust/rdma-sys", package = "rdma-sys", version = "0.1.0" }
 
 [dependencies.lazy_static]
 version = "1.4"

--- a/qvisor/src/main.rs
+++ b/qvisor/src/main.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #![allow(dead_code)]
 #![allow(non_snake_case)]
 #![allow(deref_nullptr)]
-#![feature(proc_macro_hygiene, asm)]
+#![feature(proc_macro_hygiene)]
 #![feature(naked_functions)]
 #![allow(bare_trait_objects)]
 #![feature(map_first_last)]
@@ -24,20 +23,18 @@
 #![feature(llvm_asm)]
 #![allow(deprecated)]
 #![feature(thread_id_value)]
-
 #![allow(dead_code)]
 #![allow(non_snake_case)]
 extern crate alloc;
 extern crate bit_field;
-extern crate errno;
 extern crate core_affinity;
-
+extern crate errno;
 
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
-extern crate serde;
 extern crate cache_padded;
+extern crate serde;
+extern crate serde_json;
 
 #[macro_use]
 pub mod asm;
@@ -45,23 +42,21 @@ pub mod asm;
 #[macro_use]
 pub mod print;
 
-
-pub mod qlib;
-mod memmgr;
-pub mod heap_alloc;
-mod qcall;
-mod vmspace;
-mod kvm_vcpu;
-mod syncmgr;
-pub mod namespace;
-pub mod elf_loader;
-pub mod runc;
-pub mod ucall;
-pub mod console;
-pub mod util;
 pub mod amd64_def;
+pub mod console;
+pub mod elf_loader;
+pub mod heap_alloc;
+mod kvm_vcpu;
+mod memmgr;
+pub mod namespace;
 pub mod perflog;
-
+mod qcall;
+pub mod qlib;
+pub mod runc;
+mod syncmgr;
+pub mod ucall;
+pub mod util;
+mod vmspace;
 
 #[macro_use]
 extern crate clap;
@@ -72,40 +67,39 @@ extern crate scopeguard;
 #[macro_use]
 extern crate lazy_static;
 
+extern crate libc;
 extern crate spin;
 extern crate x86_64;
-extern crate libc;
 #[macro_use]
 extern crate log;
-extern crate simplelog;
 extern crate capabilities;
-extern crate regex;
-extern crate fs2;
 extern crate caps;
+extern crate fs2;
+extern crate regex;
+extern crate simplelog;
 extern crate tabwriter;
-
 
 //pub mod kvmlib;
 
-use std::env;
-use spin::Mutex;
-use lazy_static::lazy_static;
 use alloc::sync::Arc;
+use lazy_static::lazy_static;
+use spin::Mutex;
+use std::env;
 
+use self::heap_alloc::*;
+use self::qlib::addr;
 use self::qlib::buddyallocator::MemAllocator;
-use self::qlib::{addr};
-use self::qlib::qmsg::*;
 use self::qlib::config::*;
+use self::qlib::qmsg::*;
 use self::qlib::ShareSpace;
 use self::qlib::ShareSpaceRef;
-use self::vmspace::hostfdnotifier::*;
-use self::vmspace::host_pma_keeper::*;
-use self::vmspace::kernel_io_thread::*;
 use self::runc::cmd::command::*;
-use self::heap_alloc::*;
+use self::vmspace::host_pma_keeper::*;
+use self::vmspace::hostfdnotifier::*;
+use self::vmspace::kernel_io_thread::*;
 
-use vmspace::*;
 use self::vmspace::uringMgr::*;
+use vmspace::*;
 
 const LOWER_TOP: u64 = 0x00007fffffffffff;
 const UPPER_BOTTOM: u64 = 0xffff800000000000;
@@ -114,14 +108,16 @@ pub fn AllocatorPrint(_class: usize) -> String {
     return "".to_string();
 }
 
-pub static SHARE_SPACE : ShareSpaceRef = ShareSpaceRef::New();
+pub static SHARE_SPACE: ShareSpaceRef = ShareSpaceRef::New();
 
 lazy_static! {
-    pub static ref SHARE_SPACE_STRUCT : Arc<Mutex<ShareSpace>> = Arc::new(Mutex::new(ShareSpace::default()));
+    pub static ref SHARE_SPACE_STRUCT: Arc<Mutex<ShareSpace>> =
+        Arc::new(Mutex::new(ShareSpace::default()));
     pub static ref VMS: Mutex<VMSpace> = Mutex::new(VMSpace::Init());
     pub static ref PAGE_ALLOCATOR: MemAllocator = MemAllocator::New();
     pub static ref FD_NOTIFIER: HostFdNotifier = HostFdNotifier::New();
-    pub static ref IO_MGR: vmspace::HostFileMap::IOMgr = vmspace::HostFileMap::IOMgr::Init().expect("Init IOMgr fail");
+    pub static ref IO_MGR: vmspace::HostFileMap::IOMgr =
+        vmspace::HostFileMap::IOMgr::Init().expect("Init IOMgr fail");
     pub static ref SYNC_MGR: Mutex<syncmgr::SyncMgr> = Mutex::new(syncmgr::SyncMgr::New());
     pub static ref PMA_KEEPER: HostPMAKeeper = HostPMAKeeper::New();
     pub static ref QUARK_CONFIG: Mutex<Config> = {
@@ -138,9 +134,7 @@ lazy_static! {
     pub static ref GLOCK: Mutex<()> = Mutex::new(());
 }
 
-
-
-pub const LOG_FILE : &'static str = "/var/log/quark/quark.log";
+pub const LOG_FILE: &'static str = "/var/log/quark/quark.log";
 
 pub fn InitSingleton() {
     self::qlib::InitSingleton();
@@ -154,7 +148,7 @@ fn main() {
 
     {
         let mut str = "".to_string();
-        let args : Vec<String> = env::args().collect();
+        let args: Vec<String> = env::args().collect();
         for s in &args {
             str.push_str(s);
             str.push_str(" ");
@@ -167,7 +161,7 @@ fn main() {
         Err(e) => {
             error!("the error is {:?}", e);
             ::std::process::exit(-1);
-        },
+        }
         Ok(()) => {
             //error!("successfully ...");
             ::std::process::exit(0);


### PR DESCRIPTION
There're 2 issues with latest rustc and rdma check in:
1. asm is not global any ore which failed to compile x86_64 with version 0.14.3.
2. path of rdma-sys was hardcoded, change it to relative path
3. remote asm feature attribute to remove warning as from rustc 1.59, asm is not a feature any mroe