### PR TITLE
update dependency capabilities to be from git repo ..

### DIFF
--- a/qvisor/Cargo.lock
+++ b/qvisor/Cargo.lock
@@ -131,8 +131,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 [[package]]
 name = "capabilities"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aee082d97a2cb85e1282361758d96aa5162967c34a257c6c4d7fa0711a1028f"
+source = "git+https://github.com/gcmurphy/rust-capabilities?rev=bb01f0c6#bb01f0c6fe9866317ae596193cef707c335c0d2c"
 dependencies = [
  "libc",
 ]

--- a/qvisor/Cargo.toml
+++ b/qvisor/Cargo.toml
@@ -31,7 +31,7 @@ serde = "0.9"
 serde_json = "0.9"
 serde_derive = "0.9"
 clap = "2.33.3"
-capabilities = "0.3.0"
+capabilities = { git = "https://github.com/gcmurphy/rust-capabilities", package = "capabilities", rev = "bb01f0c6"}
 regex = "1.3.9"
 fs2 = "0.4.3"
 chrono = "0.4"


### PR DESCRIPTION
as the lib is removed from crates.io. see https://crates.io/crates/capabilities/0.3.0