### PR TITLE
fix procfs file bugs

### DIFF
--- a/qlib/cpuid.rs
+++ b/qlib/cpuid.rs
@@ -564,7 +564,7 @@ impl FeatureSet {
             "address sizes\t: {} bits physical, {} bits virtual\n",
             46, 48
         );
-        res += &format!("power management:");
+        res += &format!("power management:\n");
         res += &format!("");
         return res;
     }

--- a/qlib/kernel/fs/procfs/stat.rs
+++ b/qlib/kernel/fs/procfs/stat.rs
@@ -123,7 +123,8 @@ impl StatData {
             "todo: fix self.k.ApplicationCores() is {}",
             self.k.ApplicationCores()
         );
-        for i in 0..1 as usize {
+        let cores = self.k.applicationCores;
+        for i in 0..cores as usize {
             buf += &format!("cpu{} {}\n", i, cpu.ToString());
         }
 

--- a/qlib/kernel/fs/procfs/task/mounts.rs
+++ b/qlib/kernel/fs/procfs/task/mounts.rs
@@ -131,7 +131,7 @@ impl MountInfoFile {
                 ret += "/ ";
 
                 // (5) Mount point (relative to process root).
-                ret += mountPath;
+                ret += &format!("{} ", mountPath);
 
                 // (6) Mount options.
                 let mountSource = mroot.Inode().lock().MountSource.clone();


### PR DESCRIPTION
1. no new line between each core in cpuinfo file
2. show all cpu cores in /proc/stat(although no real cpu stats displayed
   yet)
3. lack of a space between mount path and access right in mountinfo