### PR TITLE
fix tlbshootdown deadlock

### DIFF
--- a/qkernel/src/lib.rs
+++ b/qkernel/src/lib.rs
@@ -335,9 +335,9 @@ pub extern "C" fn syscall_handler(
     if SHARESPACE.config.read().KernelPagetable {
         currTask.SwitchPageTable();
     }
+    CPULocal::Myself().SetMode(VcpuMode::User);
     currTask.mm.HandleTlbShootdown();
     CPULocal::Myself().SetEnterAppTimestamp(TSC.Rdtsc());
-    CPULocal::Myself().SetMode(VcpuMode::User);
     if !(pt.rip == pt.rcx && pt.r11 == pt.eflags) {
         //error!("iret *****, pt is {:x?}", pt);
         IRet(kernalRsp)

--- a/qvisor/Cargo.lock
+++ b/qvisor/Cargo.lock
@@ -202,75 +202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
-dependencies = [
- "cfg-if 1.0.0",
- "lazy_static",
-]
-
-[[package]]
 name = "darling"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,7 +736,6 @@ dependencies = [
  "clap",
  "containerd-shim",
  "core_affinity",
- "crossbeam",
  "errno",
  "fs2",
  "kvm-bindings",

--- a/qvisor/Cargo.toml
+++ b/qvisor/Cargo.toml
@@ -53,7 +53,6 @@ containerd-shim = { git = "https://github.com/QuarkContainer/rust-extensions.git
 oci-spec = "0.5.4"
 os_pipe = "1.0.0"
 time = { version = "0.3.7", features = ["serde", "std"] }
-crossbeam = "0.8.0"
 
 [dependencies.lazy_static]
 version = "1.4"

--- a/qvisor/src/kernel_def.rs
+++ b/qvisor/src/kernel_def.rs
@@ -1,7 +1,6 @@
 use cache_padded::CachePadded;
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::Ordering;
-use crossbeam::sync::WaitGroup;
 use libc::*;
 use std::fmt;
 
@@ -28,7 +27,6 @@ use super::FD_NOTIFIER;
 use super::QUARK_CONFIG;
 use super::URING_MGR;
 use super::VMS;
-use crate::kvm_vcpu::KVMVcpuState;
 use crate::SHARE_SPACE;
 
 impl std::error::Error for Error {}
@@ -131,19 +129,16 @@ impl ShareSpace {
     }
 
     pub fn TlbShootdown(&self, vcpuMask: u64) -> u64 {
-        let wg = WaitGroup::new();
         let vcpu_len = self.scheduler.VcpuArr.len();
         for i in 1..vcpu_len {
-            let cpu = VMS.lock().vcpus[i].clone();
             if ((1 << i) & vcpuMask != 0)
                 && SHARE_SPACE.scheduler.VcpuArr[i].GetMode() == VcpuMode::User
-                && cpu.state.load(Ordering::Acquire) == (KVMVcpuState::GUEST as u64)
             {
+                let cpu = VMS.lock().vcpus[i].clone();
                 SHARE_SPACE.scheduler.VcpuArr[i].InterruptTlbShootdown();
-                cpu.interrupt(Some(wg.clone()))
+                cpu.interrupt();
             }
         }
-        wg.wait();
         return 0;
     }
 
@@ -166,12 +161,11 @@ impl ShareSpace {
                 //self.scheduler.VcpuArr[i].ResetEnterAppTimestamp();
 
                 // retry to send signal for each 2 ms
-                self.scheduler.VcpuArr[i]
-                    .SetEnterAppTimestamp(enterAppTimestamp + CLOCK_TICK / 5);
+                self.scheduler.VcpuArr[i].SetEnterAppTimestamp(enterAppTimestamp + CLOCK_TICK / 5);
                 self.scheduler.VcpuArr[i].InterruptThreadTimeout();
                 //error!("CheckVcpuTimeout {}/{}/{}/{}", i, enterAppTimestamp, now, Tsc::Scale(now - enterAppTimestamp));
                 let vcpu = VMS.lock().vcpus[i].clone();
-                vcpu.interrupt(None);
+                vcpu.interrupt();
             }
         }
     }


### PR DESCRIPTION
remove the waiting of vcpu interrupt, as we assume that kvm will interrupt the vcpu in a timely manner。
![image](https://user-images.githubusercontent.com/7891772/173486855-d055b059-b5ef-4838-9c6e-d15df200abee.png)
