### PR TITLE
Clear bitmap when unregister event

### DIFF
--- a/qlib/kernel/kernel/waiter/entry.rs
+++ b/qlib/kernel/kernel/waiter/entry.rs
@@ -87,6 +87,16 @@ impl WaitContext {
             _ => (),
         }
     }
+
+    pub fn Clear(&self) {
+        match self {
+            WaitContext::ThreadContext(t) => {
+                let context = t.borrow_mut();
+                context.waiter.Clear(context.waiterID);
+            }
+            _ => (),
+        }
+    }
 }
 
 pub struct ThreadContext {
@@ -207,8 +217,7 @@ impl WaitEntry {
     //clear the related bit of the entry in the waiter
     pub fn Clear(&self) {
         let e = self.lock();
-        let context = e.context.ThreadContext();
-        context.waiter.Clear(context.waiterID);
+        e.context.Clear();
     }
 
     pub fn Reset(&self) {

--- a/qlib/kernel/kernel/waiter/queue.rs
+++ b/qlib/kernel/kernel/waiter/queue.rs
@@ -44,6 +44,7 @@ impl Waitable for Queue {
 
     fn EventUnregister(&self, _task: &Task, e: &WaitEntry) {
         let mut q = self.write();
+        e.Clear();
         q.Remove(e)
     }
 }


### PR DESCRIPTION
Discovered when run apache-benchmark, verified with both apache-benchmark and redis benchmark.