### PR TITLE
clean up mounts and directories inside /var/lib/quark/ after container being removed

### DIFF
--- a/qvisor/src/runc/runtime/sandbox_process.rs
+++ b/qvisor/src/runc/runtime/sandbox_process.rs
@@ -55,7 +55,7 @@ use super::signal_handle::*;
 use super::util::*;
 use super::vm::*;
 
-const QUARK_SANDBOX_ROOT_PATH: &str = "/var/lib/quark/";
+pub const QUARK_SANDBOX_ROOT_PATH: &str = "/var/lib/quark/";
 
 pub struct NSRestore {
     pub fd: i32,


### PR DESCRIPTION
The "clean up" is done when "quark_d delete" is triggered.