### PR TITLE
Fix bug: terminal signal filtering, and allow remote terminal termination

### DIFF
--- a/qvisor/src/runc/shim/container.rs
+++ b/qvisor/src/runc/shim/container.rs
@@ -483,9 +483,10 @@ impl CommonContainer {
                     &fds,
                 )?;
                 process.common.pid = pid;
+                let sandboxId = self.container.Sandbox.as_ref().unwrap().ID.clone();
                 process
                     .common
-                    .CopyIO(&*self.id, pid)
+                    .CopyIO(&*self.id, pid, sandboxId)
                     .map_err(|e| Error::Common(format!("{:?}", e)))?;
                 return Ok(pid);
             }

--- a/qvisor/src/runc/shim/container_io.rs
+++ b/qvisor/src/runc/shim/container_io.rs
@@ -38,7 +38,7 @@ ioctl_write_ptr_bad!(ioctl_set_winsz, libc::TIOCSWINSZ, libc::winsize);
 use super::super::super::console::pty::*;
 use super::super::super::qlib::common::*;
 use super::super::super::qlib::linux_def::*;
-use crate::runc::sandbox::sandbox::SignalProcess;
+use crate::runc::sandbox::sandbox::SignalExecProcess;
 
 #[derive(Clone, Debug, Default)]
 pub struct ContainerStdio {
@@ -114,9 +114,9 @@ impl ContainerIO {
         }
     }
 
-    pub fn CopyIO(&self, stdio: &ContainerStdio, cid: &str, pid: i32) -> Result<()> {
+    pub fn CopyIO(&self, stdio: &ContainerStdio, cid: &str, pid: i32, sandboxId: String) -> Result<()> {
         match self {
-            Self::PtyIO(c) => return c.CopyIO(stdio, cid, pid),
+            Self::PtyIO(c) => return c.CopyIO(stdio, cid, pid, sandboxId),
             Self::None => panic!("ContainerIO::None"),
             _ => return Ok(()),
         }
@@ -203,7 +203,7 @@ impl PtyIO {
         return Ok(());
     }
 
-    pub fn CopyIO(&self, stdio: &ContainerStdio, cid: &str, pid: i32) -> Result<()> {
+    pub fn CopyIO(&self, stdio: &ContainerStdio, cid: &str, pid: i32, sandboxId: String) -> Result<()> {
         if !stdio.stdin.is_empty() {
             let tty = self.master.pty;
             let f = unsafe { File::from_raw_fd(tty) };
@@ -214,7 +214,7 @@ impl PtyIO {
                 .open(stdio.stdin.as_str())
                 .map_err(|e| Error::IOError(format!("IOErr {:?}", e)))?;
             //spawn_copy(stdin, f, None);
-            Redirect(stdin, f, None, self.pipeRead, cid, pid, true);
+            Redirect(stdin, f, None, self.pipeRead, cid, pid, true, sandboxId.clone());
         }
 
         if !stdio.stdout.is_empty() {
@@ -249,6 +249,7 @@ impl PtyIO {
                 cid,
                 pid,
                 false,
+                sandboxId.clone()
             );
         }
 
@@ -450,6 +451,7 @@ pub fn Redirect(
     cid: &str,
     pid: i32,
     filter_sig: bool,
+    sandboxId: String
 ) -> JoinHandle<()> {
     let cid = cid.to_string();
     std::thread::spawn(move || {
@@ -492,7 +494,7 @@ pub fn Redirect(
                 }
 
                 let cnt = if fd == from.as_raw_fd() {
-                    console_copy(from.as_raw_fd(), to.as_raw_fd(), &*cid, pid, filter_sig).unwrap()
+                    console_copy(from.as_raw_fd(), to.as_raw_fd(), &*cid, pid, filter_sig, &sandboxId).unwrap()
                 } else {
                     //if fd == readPipe {
                     return;
@@ -507,7 +509,7 @@ pub fn Redirect(
     })
 }
 
-fn console_copy(from: i32, to: i32, cid: &str, pid: i32, filter_sig: bool) -> Result<usize> {
+fn console_copy(from: i32, to: i32, cid: &str, pid: i32, filter_sig: bool, sandboxId: &str) -> Result<usize> {
     let mut buf: [u8; 256] = [0; 256];
     let mut cnt = 0;
     loop {
@@ -527,24 +529,35 @@ fn console_copy(from: i32, to: i32, cid: &str, pid: i32, filter_sig: bool) -> Re
         let ret = ret as usize;
         cnt += ret;
         if filter_sig {
-            filter_signal_and_write(to, &buf[..ret], cid, pid)?;
+            let rawData= buf.clone();
+            let str = String::from_utf8_lossy(&rawData[..ret]).to_string();
+            info!("filter_signal_and_write fifo to tty master to fifo, tty output {:?}", str);
+            filter_signal_and_write(to, &buf[..ret], cid, pid, sandboxId)?;
         } else {
+            let rawData= buf.clone();
+            let str = String::from_utf8_lossy(&rawData[..ret]).to_string();
+            info!("console_copy from tty slave to fifo, tty output {:?}", str);
             write_buf(to, &buf[..ret])?;
         }
     }
 }
 
-fn filter_signal_and_write(to_fd: i32, s: &[u8], cid: &str, pid: i32) -> Result<()> {
+fn filter_signal_and_write(to_fd: i32, s: &[u8], cid: &str, pid: i32, sandboxId: &str) -> Result<()> {
     let len = s.len();
     let mut offset = 0;
+    let rawData= s.clone();
     for i in 0..len {
         if let Some(sig) = get_signal(s[i]) {
             write_buf(to_fd, &s[offset..i])?;
-            SignalProcess(cid, pid, sig, true)?;
+            let str = String::from_utf8_lossy(&rawData[offset..i]).to_string();
+            info!("filter_signal_and_write, signal exist tty input {:?}", str);
+            SignalExecProcess(cid, pid, sig, true, sandboxId)?;
             offset = i + 1;
         }
     }
     if offset < len {
+        let str = String::from_utf8_lossy(&rawData[offset..len]).to_string();
+        info!("filter_signal_and_write, offset < len, tty input {:?}", str);
         write_buf(to_fd, &s[offset..len])?;
     }
     return Ok(());
@@ -566,6 +579,7 @@ fn get_signal(c: u8) -> Option<i32> {
 fn write_buf(to: i32, buf: &[u8]) -> Result<()> {
     let len = buf.len() as usize;
     let mut offset = 0;
+    info!("write_buf {:?}", buf);
     while offset < len {
         let writeCnt =
             unsafe { write(to, &buf[offset] as *const _ as *const c_void, len - offset) };

--- a/qvisor/src/runc/shim/process.rs
+++ b/qvisor/src/runc/shim/process.rs
@@ -69,10 +69,10 @@ impl Drop for CommonProcess {
 }
 
 impl CommonProcess {
-    pub fn CopyIO(&self, cid: &str, pid: i32) -> Result<()> {
+    pub fn CopyIO(&self, cid: &str, pid: i32, sandboxId: String) -> Result<()> {
         return self
             .containerIO
-            .CopyIO(&self.stdio, cid, pid)
+            .CopyIO(&self.stdio, cid, pid, sandboxId)
             .map_err(|e| Error::Other(format!("{:?}", e)));
     }
 
@@ -322,7 +322,8 @@ impl InitProcess {
             !self.no_pivot_root,
         )
         .map_err(|e| Error::Other(format!("{:?}", e)))?;
-        self.common.CopyIO(&*container.ID, 0)?;
+        let sandboxId = container.Sandbox.as_ref().unwrap().ID.clone();
+        self.common.CopyIO(&*container.ID, 0, sandboxId)?;
         return Ok(container);
     }
 

--- a/qvisor/src/runc/shim/shim_task.rs
+++ b/qvisor/src/runc/shim/shim_task.rs
@@ -46,6 +46,8 @@ use super::container::*;
 use super::super::super::runc::oci::LinuxResources;
 use super::super::super::runc::sandbox::sandbox::*;
 
+use super::container_io::{ContainerStdio, ContainerIO};
+
 type EventSender = Sender<(String, Box<dyn Message>)>;
 
 #[derive(Clone)]
@@ -177,8 +179,21 @@ impl ShimTask {
                                 ..Default::default()
                             },
                         );
+                    }
+                }
+
+                match cont.processes.get_mut(&execId) {
+                    None => {
                         return;
                     }
+                    Some(p) => {
+                        info!("terminal/io redirection thread stopped");
+                        p.common.stdio = ContainerStdio::default();
+                        p.common.containerIO = ContainerIO::default();
+                        // drop(&p.common.containerIO);
+                        // drop(&p.common.stdio);
+                        return;
+                    } 
                 }
             }
         }


### PR DESCRIPTION
Now, the `control c` sent over the console from the client can be forwarded to qkernel properly.

On top of that, we stop the io redirection thread in shim right after qkernel exec process exit so that terminal on the client side can exit properly.

Tiny issue: we got an error message "error stream protocol error: invalid exit code value "33280" after we terminate the console.

```yaoxin@yaoxin-MS-7B48:/var/log/quark$ kubectl exec -it nginx-quark /bin/sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
# 
# 
# 
# exit
error: error stream protocol error: invalid exit code value "33280"
```
