### PR TITLE
Log enhancement: enable qkernel capture log message from Libraries 

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
   "RDMAPort"      : 1,
   "PerSandboxLog" : false,
   "ReserveCpuCount": 1,
-  "ShimMode"      : false,
+  "ShimMode"      : true,
   "EnableInotify" : true,
   "ReaddirCache"  : true,
   "HiberODirect"  : true,

--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
   "RDMAPort"      : 1,
   "PerSandboxLog" : false,
   "ReserveCpuCount": 1,
-  "ShimMode"      : true,
+  "ShimMode"      : false,
   "EnableInotify" : true,
   "ReaddirCache"  : true,
   "HiberODirect"  : true,

--- a/qkernel/Cargo.lock
+++ b/qkernel/Cargo.lock
@@ -118,6 +118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +152,7 @@ dependencies = [
  "enum_dispatch",
  "hashbrown",
  "lazy_static",
+ "log",
  "scopeguard",
  "serde",
  "serde_derive",

--- a/qkernel/Cargo.toml
+++ b/qkernel/Cargo.toml
@@ -20,6 +20,7 @@ serde_derive = { version = "1.0.106", default-features = false}
 scopeguard = { version = "^1.1.0", default-features = false }
 hashbrown = "0.12.3"
 enum_dispatch = { git = "https://github.com/QuarkContainer/enum_dispatch_clone.git" }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace"] }
 
 [package.metadata.cargo-xbuild]
 sysroot_path = "../target/sysroot"

--- a/qkernel/src/lib.rs
+++ b/qkernel/src/lib.rs
@@ -220,6 +220,7 @@ extern "C" {
 pub fn Init() {
     self::fs::Init();
     self::socket::Init();
+    print::init().unwrap();
 }
 
 #[no_mangle]

--- a/qkernel/src/lib.rs
+++ b/qkernel/src/lib.rs
@@ -51,6 +51,7 @@ extern crate serde_derive;
 extern crate spin;
 extern crate x86_64;
 extern crate xmas_elf;
+extern crate log;
 
 use core::{mem, ptr};
 use core::panic::PanicInfo;


### PR DESCRIPTION
The log crate provides a single logging API that abstracts over the actual logging implementation. Libraries use the logging API provided by this crate, and the consumer of those libraries (qkernel) uses the logging implementation `SimpleLogger` to capture and print the logs to `quark.log`