### PR TITLE
remove dead code

### DIFF
--- a/qkernel/src/lib.rs
+++ b/qkernel/src/lib.rs
@@ -132,8 +132,6 @@ mod syscalls;
 
 //use self::heap::QAllocator;
 //use qlib::mem::bitmap_allocator::BitmapAllocatorWrapper;
-pub const HEAP_START: usize = 0x70_2000_0000;
-pub const HEAP_SIZE: usize = 0x1000_0000;
 
 //use buddy_system_allocator::*;
 //#[global_allocator]


### PR DESCRIPTION
`HEAP_START` and `HEAP_SIZE` are defined in `linux_def::MemoryDef::`.  Definitions in `qkernel/lib.rs` are unused and would cause confusions. 