### PR TITLE
aarch64: HyperCall64 with MMIO write (ABI proposal, may need discussion, don't merge yet)

### DIFF
--- a/qkernel/src/kernel_def.rs
+++ b/qkernel/src/kernel_def.rs
@@ -302,7 +302,25 @@ pub fn HyperCall64(type_: u16, para1: u64, para2: u64, para3: u64, para4: u64) {
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 pub fn HyperCall64(type_: u16, para1: u64, para2: u64, para3: u64, para4: u64) {
-    // TODO add HyperCall64
+    // use MMIO to cause VM exit hence "hypercall"
+    // the data does not matter, 
+    // addr of the MMIO identifies the Hypercall.
+    // x0 and x1 (w1) are used by the str instruction
+    // the 64-bit parameters 1,2,3,4 are passed via
+    // x2,x3,x4,x5
+    unsafe {
+        let data: u8 = 0;
+        asm!("
+             str w1, [x0]
+             ",
+             in("x0") type_,
+             in("w1") data,
+             in("x2") para1,
+             in("x3") para2,
+             in("x4") para3,
+             in("x5") para4,
+             )
+    }
 }
 
 impl CPULocal {

--- a/qkernel/src/kernel_def.rs
+++ b/qkernel/src/kernel_def.rs
@@ -310,10 +310,12 @@ pub fn HyperCall64(type_: u16, para1: u64, para2: u64, para3: u64, para4: u64) {
     // x2,x3,x4,x5
     unsafe {
         let data: u8 = 0;
+        let addr: u64 = MemoryDef::HYPERCALL_MMIO_BASE + (type_ as u64);
+
         asm!("
              str w1, [x0]
              ",
-             in("x0") type_,
+             in("x0") addr,
              in("w1") data,
              in("x2") para1,
              in("x3") para2,

--- a/qlib/linux_def.rs
+++ b/qlib/linux_def.rs
@@ -3013,6 +3013,9 @@ impl MemoryDef {
 
     pub const KERNEL_START_P2_ENTRY: usize = (Self::PHY_LOWER_ADDR / Self::ONE_GB) as usize; //256
     pub const KERNEL_END_P2_ENTRY: usize = (Self::PHY_UPPER_ADDR / Self::ONE_GB) as usize; //512
+                                                                                           //
+    #[cfg(target_arch = "aarch64")]
+    pub const HYPERCALL_MMIO_BASE: u64 = 0x1000_0000; // TODO use proper address
 }
 
 //mmap prot

--- a/qvisor/src/kvm_vcpu_aarch64.rs
+++ b/qvisor/src/kvm_vcpu_aarch64.rs
@@ -183,10 +183,16 @@ impl KVMVcpu {
                         interrupting.0 = false;
                         interrupting.1.clear();
                     }
-                    let para1 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R0).map_err(|e| Error::SysError(e.errno()))?;
-                    let para2 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R1).map_err(|e| Error::SysError(e.errno()))?;
-                    let para3 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R2).map_err(|e| Error::SysError(e.errno()))?;
-                    let para4 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R3).map_err(|e| Error::SysError(e.errno()))?;
+                    
+                    // reading hypercall parameters from vcpu register file
+                    // x0 and x1 (w1) are used by the str instruction
+                    // the 64-bit parameters 1,2,3,4 are passed via
+                    // x2,x3,x4,x5
+                    let para1 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R2).map_err(|e| Error::SysError(e.errno()))?;
+                    let para2 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R3).map_err(|e| Error::SysError(e.errno()))?;
+                    let para3 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R4).map_err(|e| Error::SysError(e.errno()))?;
+                    let para4 = self.vcpu.get_one_reg(_KVM_ARM64_REGS_R5).map_err(|e| Error::SysError(e.errno()))?;
+
                     if addr > (u16::MAX as u64) {
                         panic!("cpu[{}] Received hypercall id max than 255");
                     }


### PR DESCRIPTION
use `str` instruction to trigger MMIO_WRITE.  x0 and x1 are used as operands (addr and data). 
4 parameters are passed via register r2 ~ r5.

Perhaps need some discussions?  **Please don't merge yet** 

