### PR TITLE
Armdev - exclude specific x86_64 code 

### DIFF
--- a/qkernel/src/syscalls/sys_thread.rs
+++ b/qkernel/src/syscalls/sys_thread.rs
@@ -44,7 +44,7 @@ use super::super::vcpu::*;
 use super::super::SignalDef::*;
 use super::super::SHARESPACE;
 use super::sys_rusage::*;
-use arch::x86_64::arch_x86::X86fpstate;
+use arch::__arch::arch_def::ArchFPState;
 
 #[derive(Default, Debug)]
 pub struct ElfInfo {
@@ -337,7 +337,7 @@ pub fn Execvat(
             SetFs(0);
             task.tidInfo = TidInfo::default();
             task.context.fs = 0;
-            task.context.X86fpstate = Some(Box::new(X86fpstate::default()));
+            task.context.archfpstate = Some(Box::new(ArchFPState::default()));
 
             let newMM = MemoryManager::Init(false);
             let oldMM = task.mm.clone();

--- a/qkernel/src/syscalls/sys_tls.rs
+++ b/qkernel/src/syscalls/sys_tls.rs
@@ -14,7 +14,7 @@
 
 use core::mem;
 
-use super::super::arch::x86_64::context::*;
+use super::super::arch::__arch::context::MAX_ADDR64;
 use super::super::qlib::common::*;
 use super::super::qlib::linux_def::*;
 use super::super::syscalls::syscalls::*;
@@ -41,7 +41,6 @@ pub fn SysArchPrctl(task: &mut Task, args: &SyscallArguments) -> Result<i64> {
 
     match cmdCode {
         PrCtlEnum::ARCH_SET_GS => {
-            //WriteMsr(MSR::MSR_KERNEL_GS_BASE as u32, addr);
             SetGs(addr);
         }
         PrCtlEnum::ARCH_SET_FS => {
@@ -54,15 +53,11 @@ pub fn SysArchPrctl(task: &mut Task, args: &SyscallArguments) -> Result<i64> {
             //info!("after ARCH_SET_FS, the input value is {:x}, the get fs result is {:x}", addr, ReadMsr(MSR::MSR_FS_BASE as u32));
         }
         PrCtlEnum::ARCH_GET_FS => {
-            //*task.GetTypeMut::<u64>(addr)? = GetFs();
             task.CopyOutObj(&GetFs(), addr)?;
         }
         PrCtlEnum::ARCH_GET_GS => {
-            //*task.GetTypeMut::<u64>(addr)? = GetGs();
             task.CopyOutObj(&GetGs(), addr)?;
-            //unsafe {*(addr as *mut u64) = ReadMsr(MSR::MSR_KERNEL_GS_BASE as u32)}
         }
     }
-
     return Ok(0);
 }

--- a/qlib/kernel/arch/aarch64/arch_def.rs
+++ b/qlib/kernel/arch/aarch64/arch_def.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Quark Container Authors / 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//
+//NOTE: Every thing here is placeholder.
+//
+
+// Aarch64 FP state
+// NOTE: Placeholder
+#[derive(Debug)]
+pub struct Aarch64FPState {
+    pub data: [u64; 4069],
+}
+
+impl Default for Aarch64FPState {
+    fn default() -> Self {
+        Aarch64FPState {
+            data: [0u64; 4069]
+        }
+    }
+}
+
+pub type ArchFPState = Aarch64FPState;
+
+impl Aarch64FPState{
+    pub const fn Init() -> Self {
+        Aarch64FPState{
+            data: [0u64; 4069]
+        }
+    }
+
+	pub fn Fork(&self) -> Self {
+        Aarch64FPState{
+            data: [0u64; 4069]
+        }
+    }
+
+    pub fn Slice(&self) -> &'static mut [u8]{
+		 static mut dummy:  &mut [u8] = &mut [0u8];
+		unsafe{
+		 dummy as &'static mut [u8]
+		} 
+    }
+
+    pub fn SanitizeUser(&self) {}
+    pub fn Reset(&self)  {}
+    pub fn SaveFp(&self) {}
+    pub fn RestoreFp(&self) {}
+}

--- a/qlib/kernel/arch/aarch64/context.rs
+++ b/qlib/kernel/arch/aarch64/context.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Quark Container Authors / 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::super::super::{limits::LimitSet, kernel::memmgr::arch::MmapLayout};
+use super::super::super::super::common::*;
+
+
+// MAX_ADDR64 is the maximum userspace address. It is TASK_SIZE in Linux
+// for a 64-bit process.
+// ref: linux/latest/source/arch/arm64/include/asm/processor.h
+const VA_BITS_4KB_4L_PT: u16 = 48; 
+pub const MAX_ADDR64: u64 = 1 << VA_BITS_4KB_4L_PT;
+
+//
+//NOTE: Every thing here is placeholder.
+//
+
+pub struct Context64 {
+    pub data: [u64; 4069],
+}
+
+impl Context64 {
+    pub fn PIELoadAddress(l: &MmapLayout) -> Result<u64> {
+        Ok(0)
+    }
+
+    pub fn MMapRand(max: u64) -> Result<u64> {
+        Ok(0)
+    }
+
+    pub fn NewMmapLayout(min: u64, max: u64, r: &LimitSet) -> Result<MmapLayout> {
+       Ok(
+           MmapLayout{
+            ..Default::default()
+           }) 
+    }
+
+}

--- a/qlib/kernel/arch/aarch64/mod.rs
+++ b/qlib/kernel/arch/aarch64/mod.rs
@@ -12,3 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 pub mod mm;
+pub mod context;
+pub mod arch_def;

--- a/qlib/kernel/arch/mod.rs
+++ b/qlib/kernel/arch/mod.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 #[cfg(target_arch = "aarch64")]
 #[path = "./aarch64/mod.rs"]

--- a/qlib/kernel/arch/mod.rs
+++ b/qlib/kernel/arch/mod.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #[cfg(target_arch = "x86_64")]
-pub mod x86_64;
+#[path = "./x86_64/mod.rs"]
+pub mod __arch;
 #[cfg(target_arch = "aarch64")]
 #[path = "./aarch64/mod.rs"]
-pub mod aarch64;
+pub mod __arch;
+
 

--- a/qlib/kernel/arch/x86_64/arch_x86.rs
+++ b/qlib/kernel/arch/x86_64/arch_x86.rs
@@ -21,7 +21,6 @@ use super::super::super::super::cpuid::*;
 use super::super::super::asm::*;
 use super::super::super::SignalDef::*;
 use super::super::super::FP_STATE;
-//use super::super::super::super::super::kernel_def::*;
 
 // System-related constants for x86.
 
@@ -127,11 +126,13 @@ pub struct X86fpstate {
     pub size: AtomicUsize,
 }
 
+
 impl Default for X86fpstate {
     fn default() -> Self {
         return Self::Load();
     }
 }
+pub type ArchFPState = X86fpstate;
 
 impl X86fpstate {
     // minXstateBytes is the minimum size in bytes of an x86 XSAVE area, equal

--- a/qlib/kernel/arch/x86_64/context.rs
+++ b/qlib/kernel/arch/x86_64/context.rs
@@ -19,7 +19,7 @@ use super::super::super::super::linux_def::*;
 use super::super::super::kernel_util::*;
 use super::super::super::memmgr::arch::*;
 use super::super::super::SignalDef::*;
-use super::arch_x86::*;
+use super::arch_def::*;
 
 // These constants come directly from Linux.
 
@@ -91,18 +91,6 @@ pub struct Context64 {
 }
 
 impl Context64 {
-    /*pub fn New() -> Self {
-        return Self {
-            state: State {
-                Regs: unsafe {
-                    &mut *(0 as *mut PtRegs)
-                },
-                x86FPState: Arc::new(QMutex::new(X86fpstate::NewX86FPState())),
-            },
-            sigFPState: Vec::new(),
-        }
-    }*/
-
     // Fork returns an exact copy of this context.
     pub fn Fork(&self, regs: &'static mut PtRegs) -> Self {
         return Self {

--- a/qlib/kernel/arch/x86_64/mod.rs
+++ b/qlib/kernel/arch/x86_64/mod.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-pub mod arch_x86;
+#[path = "./arch_x86.rs"]
+pub mod arch_def;
+
 pub mod context;
 pub mod signal;

--- a/qlib/kernel/loader/elf.rs
+++ b/qlib/kernel/loader/elf.rs
@@ -27,7 +27,7 @@ use super::super::super::common::*;
 use super::super::super::limits::*;
 use super::super::super::linux_def::*;
 use super::super::super::platform::defs_impl::*;
-use super::super::arch::x86_64::context::*;
+use super::super::arch::__arch::context::Context64;
 use super::super::fs::file::*;
 use super::super::memmgr::*;
 use super::super::task::*;
@@ -72,19 +72,6 @@ pub struct ElfHeadersInfo {
 // parseHeader parse the ELF header, verifying that this is a supported ELF
 // file and returning the ELF program headers.
 pub fn ParseHeader(task: &mut Task, file: &File) -> Result<ElfHeadersInfo> {
-    /*let mut moptions = MMapOpts::NewFileOptions(&file)?;
-    moptions.Length = 2 * 4096;
-    moptions.Fixed = false;
-    moptions.Perms = AccessType::ReadOnly();
-    moptions.MaxPerms = AccessType::ReadOnly();
-    moptions.Private = false;
-    moptions.Offset = 0;
-
-    error!("ParseHeader 2");
-    let addr = task.mm.MMap(task, &mut moptions).expect("mmap elf head fail");
-    error!("ParseHeader 3 addr is {:x}", addr);
-    let slice = unsafe { slice::from_raw_parts(addr as *const u8, 2 * 4096) };*/
-
     let mut buf = DataBuff::New(2 * 0x1000);
     let n = match ReadAll(task, &file, &mut buf.buf, 0) {
         Err(e) => {
@@ -326,14 +313,6 @@ pub fn LoadParseElf(
                 }
 
                 let mut fileName: Vec<u8> = vec![0; header.file_size as usize]; //remove last '/0'
-
-                /*if task.Seek(fd as u64, header.offset as u64, SeekWhence::SEEK_SET as u64) == -1 {
-                    return Err(Error::ELFLoadError("read interpreter seek fail"))
-                }
-
-                if task.Read(fd as u64, &fileName[0] as *const u8 as u64, header.file_size - 1, ) != (header.file_size - 1) as i64 {
-                    return Err(Error::ELFLoadError("read interpreter fail"))
-                }*/
 
                 match ReadAll(task, file, &mut fileName, header.offset as u64) {
                     Err(e) => {

--- a/qlib/kernel/memmgr/arch.rs
+++ b/qlib/kernel/memmgr/arch.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::super::addr::*;
-use super::super::arch::x86_64::context::*;
+use super::super::arch::__arch::context::Context64;
 
 pub type MmapDirection = i32;
 
@@ -80,7 +80,7 @@ impl MmapLayout {
     }
 
     pub fn MapStackAddr(&self) -> u64 {
-        return Addr(self.MaxAddr - MMapRand(self.MaxStackRand).expect("MapStackAddr fail"))
+        return Addr(self.MaxAddr - Context64::MMapRand(self.MaxStackRand).expect("MapStackAddr fail"))
             .RoundDown()
             .unwrap()
             .0;

--- a/qlib/kernel/memmgr/mm.rs
+++ b/qlib/kernel/memmgr/mm.rs
@@ -35,7 +35,7 @@ use super::super::super::mem::areaset::*;
 use super::super::super::pagetable::*;
 use super::super::super::range::*;
 use super::super::super::vcpu_mgr::CPULocal;
-use super::super::arch::x86_64::context::*;
+use super::super::arch::__arch::context::Context64;
 use super::super::fs::dirent::*;
 use super::super::kernel::aio::aio_context::*;
 use super::super::mm::*;
@@ -45,7 +45,6 @@ use super::super::uid::*;
 use super::super::Kernel::HostSpace;
 use super::super::KERNEL_PAGETABLE;
 use super::super::PAGE_MGR;
-//use super::super::asm::*;
 use super::arch::*;
 use super::metadata::*;
 use super::syscalls::*;
@@ -233,10 +232,6 @@ impl MemoryManager {
         let gap = vmas.FindGap(MemoryDef::PHY_LOWER_ADDR);
 
         // kernel memory
-        //vmas.Insert(&gap, &Range::New(MemoryDef::PHY_LOWER_ADDR, MemoryDef::PHY_UPPER_ADDR - MemoryDef::PHY_LOWER_ADDR), vma.clone());
-        // KVM_IOEVENTFD RANGE
-        //vmas.Insert(&gap, &Range::New(MemoryDef::KVM_IOEVENTFD_BASEADDR, 0x1000), vma);
-
         vmas.Insert(
             &gap,
             &Range::New(
@@ -670,7 +665,6 @@ impl MemoryManager {
         ret += Self::VSYSCALL_MAPS_ENTRY;
 
         return ret;
-        //return ret.as_bytes().to_vec();
     }
 
     pub fn GenMapsSnapshot(&self, task: &Task) -> Vec<u8> {

--- a/qlib/kernel/mod.rs
+++ b/qlib/kernel/mod.rs
@@ -25,7 +25,7 @@ use super::control_msg::*;
 use super::pagetable::*;
 use super::singleton::*;
 
-use self::arch::x86_64::arch_x86::*;
+use self::arch::__arch::arch_def::ArchFPState;
 use self::boot::loader::*;
 use self::kernel::async_process::*;
 use self::memmgr::pma::*;
@@ -72,7 +72,7 @@ pub static KERNEL_STACK_ALLOCATOR: Singleton<AlignedAllocator> =
 pub static EXIT_CODE: Singleton<AtomicI32> = Singleton::<AtomicI32>::New();
 pub static VCPU_FREQ: AtomicI64 = AtomicI64::new(2_000_000_000); // default 2GHZ
 pub static ASYNC_PROCESS: AsyncProcess = AsyncProcess::New();
-pub static FP_STATE: X86fpstate = X86fpstate::Init();
+pub static FP_STATE: ArchFPState = ArchFPState::Init();
 pub static SUPPORT_XSAVE: AtomicBool = AtomicBool::new(false);
 pub static SUPPORT_XSAVEOPT: AtomicBool = AtomicBool::new(false);
 

--- a/qlib/kernel/task.rs
+++ b/qlib/kernel/task.rs
@@ -21,7 +21,7 @@ use core::ops::Deref;
 use core::ptr;
 use core::sync::atomic::Ordering;
 
-//use super::arch::x86_64::arch_x86::*;
+use super::arch::__arch::arch_def::ArchFPState;
 use super::super::super::kernel_def::*;
 use super::super::auth::*;
 use super::super::common::*;
@@ -243,13 +243,13 @@ impl Task {
     }
 
     pub fn SaveFp(&mut self) {
-        self.context.X86fpstate.as_ref().unwrap().SaveFp();
+        self.context.archfpstate.as_ref().unwrap().SaveFp();
         self.context.savefpsate = true;
     }
 
     pub fn RestoreFp(&mut self) {
         if self.context.savefpsate {
-            self.context.X86fpstate.as_ref().unwrap().RestoreFp();
+            self.context.archfpstate.as_ref().unwrap().RestoreFp();
             self.context.savefpsate = false;
         }
     }

--- a/qlib/kernel/taskMgr.rs
+++ b/qlib/kernel/taskMgr.rs
@@ -142,8 +142,8 @@ pub fn WaitFn() -> ! {
                 if pendingFreeStack != 0 {
                     //(*PAGE_ALLOCATOR).Free(pendingFreeStack, DEFAULT_STACK_PAGES).unwrap();
                     let task = TaskId::New(pendingFreeStack).GetTask();
-                    //free X86fpstate
-                    task.context.X86fpstate.take();
+                    //free FPstate
+                    task.context.archfpstate.take();
 
                     KERNEL_STACK_ALLOCATOR.Free(pendingFreeStack).unwrap();
                     CPULocal::SetPendingFreeStack(0);

--- a/qlib/kernel/threadmgr/task_clone.rs
+++ b/qlib/kernel/threadmgr/task_clone.rs
@@ -21,13 +21,12 @@ use super::super::super::super::kernel_def::*;
 use super::super::super::common::*;
 use super::super::super::linux_def::*;
 use super::super::super::task_mgr::*;
-use super::super::arch::x86_64::context::*;
+use super::super::arch::__arch::context::MAX_ADDR64;
 use super::super::kernel::ipc_namespace::*;
 use super::super::threadmgr::task_start::*;
 use super::super::threadmgr::thread::*;
 use super::super::SignalDef::*;
 use super::super::*;
-//use super::super::syscalls::sys_tls::*;
 use super::super::task::*;
 use super::task_block::*;
 use super::task_stop::*;
@@ -664,8 +663,8 @@ pub fn CreateCloneTask(fromTask: &Task, toTask: &mut Task, userSp: u64) {
         toTask.context.rsp = toTask.GetPtRegs() as *const _ as u64 - 8;
         toTask.context.rdi = userSp;
         toTask.context.savefpsate = true;
-        toTask.context.X86fpstate = Some(Box::new(
-            fromTask.context.X86fpstate.as_ref().unwrap().Fork(),
+        toTask.context.archfpstate = Some(Box::new(
+            fromTask.context.archfpstate.as_ref().unwrap().Fork(),
         ));
         toPtRegs.rax = 0;
         toPtRegs.rsp = userSp;

--- a/qlib/pagetable.rs
+++ b/qlib/pagetable.rs
@@ -37,7 +37,7 @@ cfg_x86_64! {
 }
 
 cfg_aarch64! {
-   pub use super::kernel::arch::aarch64::mm::pagetable::{PhysAddr, VirtAddr, PageTable,
+   pub use super::kernel::arch::__arch::mm::pagetable::{PhysAddr, VirtAddr, PageTable,
                                                          PageTableEntry, PageTableIndex,
                                                          PageTableFlags};
 

--- a/qlib/task_mgr.rs
+++ b/qlib/task_mgr.rs
@@ -24,7 +24,7 @@ use core::sync::atomic::AtomicU64;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
 
-use super::kernel::arch::x86_64::arch_x86::*;
+use super::kernel::arch::__arch::arch_def::ArchFPState;
 
 use super::vcpu_mgr::*;
 
@@ -76,7 +76,10 @@ pub struct Context {
     pub ready: AtomicU64,
     pub fs: u64,
     pub savefpsate: bool,
-    pub X86fpstate: Option<Box<X86fpstate>>,
+    //
+    // ARM PORT
+    //
+    pub archfpstate: Option<Box<ArchFPState>>,
     // job queue id
     pub queueId: AtomicUsize,
     pub links: Links,
@@ -98,7 +101,7 @@ impl Context {
 
             fs: 0,
             savefpsate: false,
-            X86fpstate: Some(Default::default()),
+            archfpstate: Some(Default::default()),
             queueId: AtomicUsize::new(0),
             links: Links::default(),
         };
@@ -249,14 +252,6 @@ impl Scheduler {
         }
 
         return wake;
-
-        /*let state = self.VcpuArr[vcpuId].State();
-        if state == VcpuState::Waiting {
-            self.VcpuArr[vcpuId].Wakeup();
-            return true
-        }
-
-        return false*/
     }
 }
 


### PR DESCRIPTION
This commit identifies, and excludes x86_64 code "qlib/kernel/arch/x86_64/*" which was still included when build for aarch64. This seems to be mostly code related to context save/switch.
AFAIK context save/switch for aarch64 is still not present, so ensure that the branch still builds, dummy structs/functions are placed in "qlib/kernel/arch/aarch64/*".  