### PR TITLE
[aarch64] fix page table flags; add identity mapping of device MMIO

### DIFF
--- a/qlib/addr.rs
+++ b/qlib/addr.rs
@@ -247,7 +247,7 @@ pub struct PageOpts(PageTableFlags);
 impl PageOpts {
     //const Empty : PageTableFlags = PageTableFlags::PRESENT & PageTableFlags::WRITABLE; //set 0
     pub fn New(user: bool, write: bool, exec: bool) -> Self {
-        let mut flags = PageTableFlags::VALID | PageTableFlags::MT_NORMAL;
+        let mut flags = PageTableFlags::VALID | PageTableFlags::MEM_NORMAL;
         if !write {
             flags |= PageTableFlags::READ_ONLY;
         }
@@ -340,18 +340,18 @@ impl PageOpts {
 	// Set a collection of PT flags to configure 
 	// device memory for MMIO.
     pub fn SetDeviceMMIO(&mut self) -> &mut Self {
-		self.0 |= PageTableFlags::DEVICE_FLAGS;
-		info!("set device mmio flags {}", self.0.bits());
+        self.0 |= PageTableFlags::DEVICE_FLAGS;
         return self;
     }
 
     pub fn SetBlock(&mut self) -> &mut Self {
-		self.0 &= !PageTableFlags::TABLE;
+        self.0 &= !PageTableFlags::TABLE;
         return self;
     }
 
     pub fn SetMtNormal(&mut self) -> &mut Self {
-        self.0 |= PageTableFlags::MT_NORMAL;
+        self.0 &= !PageTableFlags::MEM_DEVICE;
+        self.0 |= PageTableFlags::MEM_NORMAL;
         return self;
     }
 

--- a/qlib/addr.rs
+++ b/qlib/addr.rs
@@ -336,6 +336,19 @@ impl PageOpts {
         self.0 &= !PageTableFlags::NON_GLOBAL;
         return self;
     }
+	
+	// Set a collection of PT flags to configure 
+	// device memory for MMIO.
+    pub fn SetDeviceMMIO(&mut self) -> &mut Self {
+		self.0 |= PageTableFlags::DEVICE_FLAGS;
+		info!("set device mmio flags {}", self.0.bits());
+        return self;
+    }
+
+    pub fn SetBlock(&mut self) -> &mut Self {
+		self.0 &= !PageTableFlags::TABLE;
+        return self;
+    }
 
     pub fn SetMtNormal(&mut self) -> &mut Self {
         self.0 |= PageTableFlags::MT_NORMAL;

--- a/qlib/kernel/arch/aarch64/mm/pagetable.rs
+++ b/qlib/kernel/arch/aarch64/mm/pagetable.rs
@@ -118,35 +118,43 @@ impl fmt::Debug for PageTableEntry {
 bitflags! {
     /// Possible flags for a page table entry.
     pub struct PageTableFlags: u64 {
+        const ZERO            = 0;
+        const PRESENT         = 1;
         const VALID           = 1;
         const TABLE           = 1 << 1;
+        // [11:2] Lower page/block attributes
+        // [4:2] Memory Attributes
+        // TODO avoid setting multiple bits
         const PAGE            = 3;      // 4k granule
-        const DEVICE          = 1 << 2; // device mmio
+        const MEM_DEVICE      = 0x1 << 2; // device mmio
+        const MEM_NORMAL      = 0x4 << 2;
         const NC              = 1 << 3; // non cachable
+        const NS              = 1 << 5; // non secure
+        // [7:6] Access permissions (AP)
         const USER_ACCESSIBLE = 1 << 6; // allow EL0 access
         const READ_ONLY       = 1 << 7;
-        const OUTTER_SHARABLE = 2 << 8;
-        const SHARED          = 3 << 8; // *INNER SHARABLE
+        // [9:8] Shareability (SH)
+        const OUTER_SHAREABLE = 2 << 8;
+        const INNER_SHAREABLE = 3 << 8;
         const ACCESSED        = 1 << 10;
         const NON_GLOBAL      = 1 << 11;
+
+        // Upper page/block attributes
         const DBM             = 1 << 51;
+        const CONTIGUOUS      = 1 << 52;
         const PXN             = 1 << 53;
         const UXN             = 1 << 54;
         const DIRTY           = 1 << 55;
 
-        const ZERO            = 0;
-        const PRESENT         = 1;
-
-        const MT_DEVICE_NGNRE = 0x1 << 2;
-        const MT_NORMAL       = 0x4 << 2;
         // A handy collection of flags that specify device memory
-        const DEVICE_FLAGS    = Self::DEVICE.bits|
-                                Self::UXN.bits|
+        // TODO remove this composition from PageTableFlags and
+        // add a function set all individual flags in addr.rs
+        const DEVICE_FLAGS    = Self::MEM_DEVICE.bits|
                                 Self::PAGE.bits|
                                 Self::NC.bits|
-                                Self::SHARED.bits;
-        // TODO complete this section see 
-        // https://rcore-os.cn/arceos/src/page_table_entry/arch/aarch64.rs.html#12 
+                                Self::INNER_SHAREABLE.bits|
+                                Self::PXN.bits|
+                                Self::UXN.bits;
     }
 }
 

--- a/qlib/kernel/arch/aarch64/mm/pagetable.rs
+++ b/qlib/kernel/arch/aarch64/mm/pagetable.rs
@@ -87,6 +87,7 @@ impl PageTableEntry {
     /// Map the entry to the specified physical address with the specified flags.
     #[inline]
     pub fn set_addr(&mut self, addr: PhysAddr, flags: PageTableFlags) {
+		// TODO the position of the bits
         assert!(addr.is_aligned(4096u64));
         self.entry = (addr.as_u64()) | flags.bits();
     }
@@ -119,9 +120,13 @@ bitflags! {
     pub struct PageTableFlags: u64 {
         const VALID           = 1;
         const TABLE           = 1 << 1;
-        const USER_ACCESSIBLE = 1 << 6;
+        const PAGE            = 3;      // 4k granule
+        const DEVICE          = 1 << 2; // device mmio
+        const NC              = 1 << 3; // non cachable
+        const USER_ACCESSIBLE = 1 << 6; // allow EL0 access
         const READ_ONLY       = 1 << 7;
-        const SHARED          = 3 << 8;
+        const OUTTER_SHARABLE = 2 << 8;
+        const SHARED          = 3 << 8; // *INNER SHARABLE
         const ACCESSED        = 1 << 10;
         const NON_GLOBAL      = 1 << 11;
         const DBM             = 1 << 51;
@@ -132,8 +137,16 @@ bitflags! {
         const ZERO            = 0;
         const PRESENT         = 1;
 
-        const MT_DEGICE_NGNRE = 0x1 << 2;
+        const MT_DEVICE_NGNRE = 0x1 << 2;
         const MT_NORMAL       = 0x4 << 2;
+        // A handy collection of flags that specify device memory
+        const DEVICE_FLAGS    = Self::DEVICE.bits|
+                                Self::UXN.bits|
+                                Self::PAGE.bits|
+                                Self::NC.bits|
+                                Self::SHARED.bits;
+        // TODO complete this section see 
+        // https://rcore-os.cn/arceos/src/page_table_entry/arch/aarch64.rs.html#12 
     }
 }
 

--- a/qlib/linux_def.rs
+++ b/qlib/linux_def.rs
@@ -3014,8 +3014,9 @@ impl MemoryDef {
     pub const KERNEL_START_P2_ENTRY: usize = (Self::PHY_LOWER_ADDR / Self::ONE_GB) as usize; //256
     pub const KERNEL_END_P2_ENTRY: usize = (Self::PHY_UPPER_ADDR / Self::ONE_GB) as usize; //512
                                                                                            //
+    // use 2 pages below PHY_LOWER_ADDR as MMIO base.
     #[cfg(target_arch = "aarch64")]
-    pub const HYPERCALL_MMIO_BASE: u64 = 0x1000_0000; // TODO use proper address
+    pub const HYPERCALL_MMIO_BASE: u64 = Self::KVM_IOEVENTFD_BASEADDR - Self::PAGE_SIZE;
 }
 
 //mmap prot

--- a/qvisor/src/kvm_vcpu_aarch64.rs
+++ b/qvisor/src/kvm_vcpu_aarch64.rs
@@ -242,27 +242,26 @@ impl KVMVcpu {
     }
 
     fn setup_registers(&self) -> Result<()> {
-        // // tcr_el1
-        // let data = _TCR_TXSZ_VA48 |  _TCR_CACHE_FLAGS | _TCR_SHARED | _TCR_TG_FLAGS |  _TCR_ASID16 |  _TCR_IPS_40BITS;
-        // //let data = _TCR_TXSZ_VA48 | _TCR_TG_FLAGS | _TCR_IPS_40BITS;
-        // self.vcpu.set_one_reg(_KVM_ARM64_REGS_TCR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
-        // // mair_el1
-        // let data = _MT_EL1_INIT;
-        // self.vcpu.set_one_reg(_KVM_ARM64_REGS_MAIR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
-        // // ttbr0_el1
-        // let data = VMS.lock().pageTables.GetRoot();
-        // self.vcpu.set_one_reg(_KVM_ARM64_REGS_TTBR0_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
-        // // TODO set ttbr1_el1
-        // // cntkctl_el1
-        // let data = _CNTKCTL_EL1_DEFAULT;
-        // self.vcpu.set_one_reg(_KVM_ARM64_REGS_CNTKCTL_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
-        // // cpacr_el1
-        // let data = 0;
-        // self.vcpu.set_one_reg(_KVM_ARM64_REGS_CPACR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
-        // // sctlr_el1
-        // let data = _SCTLR_EL1_DEFAULT;
-        // //let data = _SCTLR_M;
-        // self.vcpu.set_one_reg(_KVM_ARM64_REGS_SCTLR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
+        // tcr_el1
+        let data = _TCR_TXSZ_VA48 |  _TCR_CACHE_FLAGS | _TCR_SHARED | _TCR_TG_FLAGS |  _TCR_ASID16 |  _TCR_IPS_40BITS;
+        self.vcpu.set_one_reg(_KVM_ARM64_REGS_TCR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
+        // mair_el1
+        //
+        let data = _MT_EL1_INIT;
+        self.vcpu.set_one_reg(_KVM_ARM64_REGS_MAIR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
+        // ttbr0_el1
+        let data = VMS.lock().pageTables.GetRoot();
+        self.vcpu.set_one_reg(_KVM_ARM64_REGS_TTBR0_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
+        // TODO set ttbr1_el1
+        // cntkctl_el1
+        let data = _CNTKCTL_EL1_DEFAULT;
+        self.vcpu.set_one_reg(_KVM_ARM64_REGS_CNTKCTL_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
+        // cpacr_el1
+        let data = 0;
+        self.vcpu.set_one_reg(_KVM_ARM64_REGS_CPACR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
+        // sctlr_el1
+        let data = _SCTLR_EL1_DEFAULT;
+        self.vcpu.set_one_reg(_KVM_ARM64_REGS_SCTLR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
         // tpidr_el1 has to be set in kernel
         // sp_el1
         let data = self.topStackAddr;

--- a/qvisor/src/runc/runtime/vm.rs
+++ b/qvisor/src/runc/runtime/vm.rs
@@ -349,13 +349,17 @@ impl VirtualMachine {
                 addr::Addr(MemoryDef::PHY_LOWER_ADDR),
                 opts.Val(),
             )?;
+ 
+            let mut opts = addr::PageOpts::Zero();
 
-            // vms.KernelMap(
-            //     addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE),
-            //     addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE + 0x1000),
-            //     addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE),
-            //     opts.Val(),
-            // )?;
+			opts.SetWrite().SetGlobal().SetPresent().SetAccessed();
+			opts.SetDeviceMMIO();
+            vms.KernelMap(
+                addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE),
+                addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE + 0x1000),
+                addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE),
+				opts.Val(),
+            )?;
             autoStart = args.AutoStart;
             vms.pivot = args.Pivot;
             vms.args = Some(args);


### PR DESCRIPTION
- HYPERCALL_MMIO_BASE is relocated to 2 pages below PHY_LOW_ADDR  (256G - 8K)
- It turns out that with MMU we don't need to align (mmio) hypercall addresses to 8 bytes.

test run from our arm machine (Neoverse-N1). I annotated the hypercalls. 

```
tack is 45c0080000
[INFO] [0/225894469457] enter vcpu run
[INFO] [0/225894469459] kvmRet: MmioWrite(274877898760, [0, 0, 0, 0])
[INFO] [0/225894469459] handle hypercall 274877898760    <- HYPERCALL_PRINT
[INFO] [0/225894469459] paras:45c007fdd0 0 0 0
0x40003d622f 0x45c007fde0: enter rust_main, haha         <- rust_main
[INFO] [0/225894469459] enter vcpu run
[INFO] [0/225894469460] kvmRet: MmioWrite(274877898760, [0, 0, 0, 0])
[INFO] [0/225894469460] handle hypercall 274877898760    <- HYPERCALL_PRINT
[INFO] [0/225894469460] paras:45c007fc68 0 0 0
0x40003d6244 0x45c007fc78: init global allocator   
[INFO] [0/225894469460] enter vcpu run
[INFO] [0/225894469460] kvmRet: MmioWrite(274877898760, [0, 0, 0, 0])
[INFO] [0/225894469460] handle hypercall 274877898760    <- HYPERCALL_PRINT
[INFO] [0/225894469460] paras:45c007fc68 0 0 0
0x40003d6259 0x45c007fc78: init global allocator2        <- rust_main
[INFO] [0/225894469460] enter vcpu run
[INFO] [0/225894469461] kvmRet: MmioWrite(274877898757, [0, 0, 0, 0])
[INFO] [0/225894469461] handle hypercall 274877898757    <- HYPERCALL_MSG
[INFO] [0/225894469461] paras:240 0 3f 2
[INFO] [0/225894469461] enter vcpu run
[INFO] [0/225894469462] kvmRet: MmioWrite(274877898760, [0, 0, 0, 0])
[INFO] [0/225894469462] handle hypercall 274877898760    <- HYPERCALL_PRINT
[INFO] [0/225894469462] paras:45c007fc68 0 0 0
0x40003d626f 0x45c007fc78: init sharespace               <- rust_main
[INFO] [0/225894469462] enter vcpu run
[INFO] [0/225894469462] kvmRet: MmioWrite(274877898757, [0, 0, 0, 0])
[INFO] [0/225894469462] handle hypercall 274877898757    <- HYPERCALL_MSG
[INFO] [0/225894469462] paras:240 0 3f 3                 <- task.rs:154
[INFO] [0/225894469463] enter vcpu run                                  
[INFO] [0/225894469466] kvmRet: MmioWrite(274877898757, [0, 0, 0, 0])
[INFO] [0/225894469466] handle hypercall 274877898757    <- HYPERCALL_MSG
[INFO] [0/225894469466] paras:237 0 0 0                  <- task.rs:383
[INFO] [0/225894469466] enter vcpu run
[INFO] [0/225894469467] kvmRet: MmioWrite(274877898773, [0, 0, 0, 0])
[INFO] [0/225894469467] handle hypercall 274877898773    <- HYPERCALL_VCPU_DEBUG
[INFO] [0/225894469467] paras:0 0 0 0
[ERROR] [0/225894469467] HYPERCALL_VCPU_DEBUG
[INFO] [0/225894469467] enter vcpu run
                                                         <- HANGS HERE
```