### PR TITLE
[RFC] Add exception table and syscall handler

### DIFF
--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -1,6 +1,309 @@
+use super::super::syscall_dispatch_aarch64;
+use crate::qlib::linux_def::MmapProt;
+use crate::qlib::addr::AccessType;
+use crate::qlib::kernel::SignalDef::PtRegs;
 pub unsafe fn InitSingleton() {
 }
 
 pub fn init() {
-    // TODO load IDT
+    // TODO set up GIC
+}
+
+use core::arch::asm;
+
+
+pub struct EsrDefs{}
+pub struct ISSDataAbort {}
+pub struct ISSInstrAbort {}
+
+// TODO move the defs to another module if it's too big.
+impl EsrDefs{
+    // ESR defs for Exception Class
+    pub const ESR_IL:u64            = 0x01 << 25;
+    pub const ESR_EC_SHIFT:u64      = 26;
+    pub const ESR_EC_MASK:u64       = 0x3f << 26;
+    pub const EC_UNKNOWN:u64        = 0x00;    /* Unkwn exception */
+    pub const EC_FP_SIMD:u64        = 0x07;    /* FP/SIMD trap */
+    pub const EC_BRANCH_TGT:u64     = 0x0d;    /* Branch target exception */
+    pub const EC_ILL_STATE:u64      = 0x0e;    /* Illegal execution state */
+    pub const EC_SVC:u64            = 0x15;    /* SVC trap */
+    pub const EC_MSR:u64            = 0x18;    /* MSR/MRS trap */
+    pub const EC_FPAC:u64           = 0x1c;    /* Faulting PAC trap */
+    pub const EC_INSN_ABORT_L:u64   = 0x20;    /* Instruction abort, from lower EL */
+    pub const EC_INSN_ABORT:u64     = 0x21;    /* Instruction abort, from same EL */ 
+    pub const EC_PC_ALIGN:u64       = 0x22;    /* PC alignment fault */
+    pub const EC_DATA_ABORT_L:u64   = 0x24;    /* Data abort, from lower EL */
+    pub const EC_DATA_ABORT:u64     = 0x25;    /* Data abort, from same EL */ 
+    pub const EC_SP_ALIGN:u64       = 0x26;    /* SP alignment fault */
+    pub const EC_TRAP_FP:u64        = 0x2c;    /* Trapped FP exception */
+    pub const EC_SERROR:u64         = 0x2f;    /* SError interrupt */
+    pub const EC_SOFTSTP_EL0:u64    = 0x32;    /* Software Step, from lower EL */
+    pub const EC_SOFTSTP_EL1:u64    = 0x33;    /* Software Step, from same EL */
+    pub const EC_WATCHPT_EL1:u64    = 0x35;    /* Watchpoint, from same EL */
+    pub const EC_BRK:u64            = 0x3c;    /* Breakpoint */
+
+    pub const ESR_CM:u64            = 0x01 << 8;     /* Cache Maintenance */
+    pub const ESR_WNR:u64           = 0x01 << 6;     /* Write not read */
+
+    // ESR defs for ISS
+    pub const ISS_FNV:u64       = 0x01 << 10;      /* FAR not valid */
+    pub const ISS_DFSC_MASK:u64 = 0x3f << 0;    /* DFSC and IFSC masks are the same */
+    // Access Size Fault L0~3
+    pub const DFSC_ASF_L0:u64  = 0x0;
+    pub const DFSC_ASF_L1:u64  = 0x1;
+    pub const DFSC_ASF_L2:u64  = 0x2;
+    pub const DFSC_ASF_L3:u64  = 0x3;
+
+    // Translation Fault L0~3
+    pub const DFSC_TF_L0:u64   = 0x4;
+    pub const DFSC_TF_L1:u64   = 0x5;
+    pub const DFSC_TF_L2:u64   = 0x6;
+    pub const DFSC_TF_L3:u64   = 0x7;
+
+    // Access Flag Fault L0~3
+    pub const DFSC_AF_L0:u64   = 0x8;      /* if FEAT_LPA2 is implmented */
+    pub const DFSC_AF_L1:u64   = 0x9;
+    pub const DFSC_AF_L2:u64   = 0xa;
+    pub const DFSC_AF_L3:u64   = 0xb;
+
+    // Permission Fault L0 ~ 3
+    pub const DFSC_PF_L0:u64   = 0xc;      /* if FEAT_LPA2 is implemented */
+    pub const DFSC_PF_L1:u64   = 0xd;
+    pub const DFSC_PF_L2:u64   = 0xe;
+    pub const DFSC_PF_L3:u64   = 0xf;
+
+    // Synchronous External Abort (SEA)
+    // not on translation table walk
+    pub const DFSC_SEA:u64      = 0x10;
+    // on translation table walk, L -1~3
+    pub const DFSC_SEA_M1:u64   = 0x13;     /* if FEAT_LPA2 is implemented*/
+    pub const DFSC_SEA_L0:u64  = 0x14;
+    pub const DFSC_SEA_L1:u64  = 0x15;
+    pub const DFSC_SEA_L2:u64  = 0x16;
+    pub const DFSC_SEA_L3:u64  = 0x17;
+
+    // Synchronous parity or ECC error when FEAT_RAS NOT implemented.
+    // not on table walk
+    pub const DFSC_ECC:u64      = 0x18;
+    // on table walk: L-1~3
+    pub const DFSC_ECC_M1:u64   = 0x1b;
+    pub const DFSC_ECC_L0:u64  = 0x1c;
+    pub const DFSC_ECC_L1:u64  = 0x1d;
+    pub const DFSC_ECC_L2:u64  = 0x1e;
+    pub const DFSC_ECC_L3:u64  = 0x1f;
+
+    pub const DFSC_ALIGN:u64    = 0x21;
+
+    // the Granule Protection Faults
+    // GPF on table walk, L-1~3
+    pub const DFSC_GPF_M1:u64   = 0x23;
+    pub const DFSC_GPF_L0:u64  = 0x23;
+    pub const DFSC_GPF_L1:u64  = 0x25;
+    pub const DFSC_GPF_L2:u64  = 0x26;
+    pub const DFSC_GPF_L3:u64  = 0x27;
+    // GPF not on table walk
+    pub const DFSC_GPF:u64      = 0x28;
+
+    pub const DFSC_ASF_M1:u64   = 0x29;
+    pub const DFSC_TF_M1:u64    = 0x2b;
+
+    pub const DFSC_TLB_CONFLICT:u64 = 0x30;
+    // unsupported atomic hardware update
+    pub const DFSC_UAHU:u64     = 0x31;
+
+    #[inline]
+    pub fn GetExceptionFromESR(esr:u64) -> u64{
+        return (esr & EsrDefs::ESR_EC_MASK) >> EsrDefs::ESR_EC_SHIFT;
+    }
+
+    #[inline]
+    pub fn IsCM(esr:u64) -> bool {
+        return (esr & EsrDefs::ESR_CM) != 0;
+    }
+
+    #[inline]
+    pub fn IsWnR(esr:u64) -> bool {
+        return (esr & EsrDefs::ESR_WNR) != 0;
+    }
+}
+
+pub fn GetEsrEL1() -> u64 {
+    unsafe {
+        let value:u64;
+        asm!(
+            "mrs  {}, esr_el1",
+            out(reg) value,
+           );
+        return value;
+    }
+}
+
+// TODO, the FAR is only valid when ESR.ISS.FnV==0
+// For faults other than data/instr aborts, this flag
+// should be checked before using FAR.
+pub fn GetFarEL1() -> u64 {
+    unsafe {
+        let value:u64;
+        asm!(
+            "mrs  {}, far_el1",
+            out(reg) value,
+           );
+        return value;
+    }
+}
+
+pub fn GetException() -> u64{
+    let esr:u64 = GetEsrEL1();
+    return EsrDefs::GetExceptionFromESR(esr);
+}
+
+
+
+#[no_mangle]
+pub extern "C" fn exception_handler_unhandled(_ptregs_addr:usize, exception_type:usize){
+    // MUST CHECK ptr!=0 before dereferencing
+    // ptr == 0 indicates an empty entry in the exception table,
+    // in which case the context won't be saved/restored by the wrapper
+    // and this function MUST NOT return
+    panic!("unhandled exception - {}",
+           match exception_type {
+               0 => "EL1T_SYN",
+               1 => "EL1T_IRQ",
+               2 => "EL1T_FIQ",
+               3 => "EL1T_SERROE",
+               4 => "EL1H_SYN",
+               5 => "EL1H_IRQ",
+               6 => "EL1H_FIQ",
+               7 => "EL1H_SERROE",
+               _ => "NON-DEFINED",
+          }
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn exception_handler_el1h_sync(ptregs_addr:usize){
+    let esr = GetEsrEL1();
+    let ec = EsrDefs::GetExceptionFromESR(esr);
+
+    match ec {
+        EsrDefs::EC_DATA_ABORT => {
+            let far = GetFarEL1();
+            MemAbortKernel(ptregs_addr, esr, far, false);
+        },
+        EsrDefs::EC_INSN_ABORT => {
+            let far = GetFarEL1();
+            MemAbortKernel(ptregs_addr, esr, far, true);
+        },
+        _ => {
+            panic!("unhandled sync exception from el1: {}\n", ec);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn exception_handler_el1h_irq(ptregs_addr:usize){
+    return exception_handler_unhandled(ptregs_addr, 5);
+}
+#[no_mangle]
+pub extern "C" fn exception_handler_el1h_fiq(ptregs_addr:usize){
+    return exception_handler_unhandled(ptregs_addr, 6);
+}
+#[no_mangle]
+pub extern "C" fn exception_handler_el1h_serror(ptregs_addr:usize){
+    return exception_handler_unhandled(ptregs_addr, 7);
+}
+
+// TODO add parameter to the handler
+// TODO implement el0_64_sync handler for syscalls
+#[no_mangle]
+pub extern "C" fn exception_handler_el0_sync(ptregs_addr:usize){
+    let esr = GetEsrEL1();
+    let ec = EsrDefs::GetExceptionFromESR(esr);
+    if ptregs_addr == 0 {
+        panic!("exception frame is null pointer\n")
+    }
+    match ec {
+        EsrDefs::EC_SVC => {
+            // arm64 linux syscall calling convention
+            // TODO maybe there is a better/safer way of this pointer cast
+            let ctx_p = ptregs_addr as *mut PtRegs;
+            let ctx_p = ctx_p.cast::<PtRegs>();
+            let ctx = unsafe { &mut *ctx_p };
+            // syscall number from w8
+            let call_no = ctx.regs[8] as u32;
+            let arg0 = ctx.regs[0];
+            let arg1 = ctx.regs[1];
+            let arg2 = ctx.regs[2];
+            let arg3 = ctx.regs[3];
+            let arg4 = ctx.regs[4];
+            let arg5 = ctx.regs[5];
+            // write syscall ret to x0
+            ctx.regs[0] = syscall_dispatch_aarch64(call_no,arg0,arg1,arg2,arg3,arg4,arg5);
+            // TODO do we need to write the "second ret val" back to x1?
+        },
+        EsrDefs::EC_DATA_ABORT_L => {
+            let far = GetFarEL1();
+            MemAbortUser(ptregs_addr, esr, far, false);
+        },
+        EsrDefs::EC_INSN_ABORT_L => {
+            let far = GetFarEL1();
+            MemAbortUser(ptregs_addr, esr, far, true);
+        },
+        _ => {
+            panic!("unhandled sync exception from el0: {}\n", ec);
+        }
+        // TODO (default case) for a unhandled exception from user,
+        // the kill the user process instead of panicing
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn exception_handler_el0_irq(){return;}
+#[no_mangle]
+pub extern "C" fn exception_handler_el0_fiq(){return;}
+#[no_mangle]
+pub extern "C" fn exception_handler_el0_serror(){return;}
+
+#[inline]
+pub fn GetFaultAccessType(esr:u64, is_exe:bool) -> AccessType{
+    if is_exe {
+        return AccessType(MmapProt::PROT_EXEC);
+    }
+    if !EsrDefs::IsCM(esr) && EsrDefs::IsWnR(esr){
+        return AccessType(MmapProt::PROT_WRITE)
+    }
+    return AccessType(MmapProt::PROT_READ);
+
+}
+
+pub fn MemAbortUser(ptregs_addr:usize, esr:u64, far:u64, is_instr:bool){
+    debug!("get {} abort fault from el0",
+           match is_instr {
+               true  => "instruction",
+               false => "data",
+           });
+    let dfsc = esr & EsrDefs::ISS_DFSC_MASK;
+    let access_type = GetFaultAccessType(esr, is_instr);
+    match dfsc {
+        _ => {
+            // TODO insert proper handler
+            panic!("DFSC/IFSC == 0x{:02x}, FAR == {}, faulty access type = {}",  dfsc, far, access_type.String());
+        },
+    }
+}
+
+pub fn MemAbortKernel(ptregs_addr:usize, esr:u64, far:u64, is_instr:bool){
+    debug!("get {} abort fault from el1",
+           match is_instr {
+               true  => "instruction",
+               false => "data",
+           });
+    let dfsc = esr & EsrDefs::ISS_DFSC_MASK;
+    let access_type = GetFaultAccessType(esr, is_instr);
+    match dfsc {
+        _ => {
+            // TODO insert proper handler
+            panic!("DFSC/IFSC == 0x{:02x}, FAR == {}, faulty access type = {}",  dfsc, far, access_type.String());
+        },
+    }
 }

--- a/qkernel/src/lib.rs
+++ b/qkernel/src/lib.rs
@@ -191,8 +191,15 @@ pub fn SingletonInit() {
     }
 }
 
+#[cfg(target_arch="x86_64")]
 extern "C" {
     pub fn syscall_entry();
+}
+
+
+#[cfg(target_arch="aarch64")]
+extern "C" {
+    pub fn vector_table();
 }
 
 pub fn Init() {
@@ -202,6 +209,7 @@ pub fn Init() {
 }
 
 #[no_mangle]
+#[cfg(target_arch = "x86_64")]
 pub extern "C" fn syscall_handler(
     arg0: u64,
     arg1: u64,
@@ -256,16 +264,6 @@ pub extern "C" fn syscall_handler(
                 unsafe { mem::transmute(nr as u64) }
             } else if SysCallID::sys_socket_produce as u64 <= nr && nr < SysCallID::EXTENSION_MAX as u64
             {
-                unsafe { mem::transmute(nr as u64) }
-            } else {
-                nr = SysCallID::UnknowSyscall as _;
-                SysCallID::UnknowSyscall
-            };
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            callId = if nr < SysCallID::UnknowSyscall as u64 {
                 unsafe { mem::transmute(nr as u64) }
             } else {
                 nr = SysCallID::UnknowSyscall as _;
@@ -330,6 +328,116 @@ pub extern "C" fn syscall_handler(
     } else {
         SyscallRet(kernalRsp)
     }
+}
+
+// syscall_handler implementation for aarch64:
+// Unlike x86, this function is NOT directly called 
+// from the asm code (vector). The C calling convention
+// is not necessary here.
+// TODO move this function to a proper place.
+#[no_mangle]
+#[cfg(target_arch = "aarch64")]
+pub fn syscall_dispatch_aarch64(
+    call_no: u32,
+    _arg0: u64,
+    _arg1: u64,
+    _arg2: u64,
+    _arg3: u64,
+    _arg4: u64,
+    _arg5: u64,
+) -> u64 {
+    CPULocal::Myself().SetMode(VcpuMode::Kernel);
+
+    let currTask = task::Task::Current();
+    currTask.AccountTaskLeave(SchedState::RunningApp);
+
+    let mut nr = call_no as u64;
+
+    let startTime = TSC.Rdtsc();
+    let enterAppTimestamp = CPULocal::Myself().ResetEnterAppTimestamp() as i64;
+    let worktime = Tsc::Scale(startTime - enterAppTimestamp) * 1000; // the thread has used up time slot
+    if worktime > CLOCK_TICK {
+        taskMgr::Yield();
+    }
+
+    let res;
+    let args = SyscallArguments {
+        arg0: _arg0,
+        arg1: _arg1,
+        arg2: _arg2,
+        arg3: _arg3,
+        arg4: _arg4,
+        arg5: _arg5,
+    };
+
+    let mut tid = 0;
+    let mut pid = 0;
+    let mut callId: SysCallID = SysCallID::UnknowSyscall;
+
+    let debugLevel = SHARESPACE.config.read().DebugLevel;
+
+    if debugLevel > DebugLevel::Error {
+        let llevel = SHARESPACE.config.read().LogLevel;
+        callId = if nr < SysCallID::UnknowSyscall as u64 {
+            unsafe { mem::transmute(nr as u64) }
+        } else {
+            nr = SysCallID::UnknowSyscall as _;
+            SysCallID::UnknowSyscall
+        };
+
+        if llevel == LogLevel::Complex {
+            tid = currTask.Thread().lock().id;
+            pid = currTask.Thread().ThreadGroup().ID();
+            use qlib::kernel::arch::__arch::arch_def::Context;
+            unsafe{
+                info!("({}/{})------get call id {:?} arg0:{:x}, 1:{:x}, 2:{:x}, 3:{:x}, 4:{:x}, 5:{:x}, userstack:{:x}, return address:{:x}, fs:{:x}",
+                    tid, pid, callId, _arg0, _arg1, _arg2, _arg3, _arg4, _arg5, currTask.GetPtRegs().get_stack_pointer(),  (*(currTask.GetContext() as *const Context)).pc, GetFs());
+            }
+        } else if llevel == LogLevel::Simple {
+            tid = currTask.Thread().lock().id;
+            pid = currTask.Thread().ThreadGroup().ID();
+            info!(
+                "({}/{})------get call id {:?} arg0:{:x}",
+                tid, pid, callId, _arg0
+            );
+        }
+    }
+
+    let currTask = task::Task::Current();
+
+    let state = SysCall(currTask, nr, &args);
+    MainRun(currTask, state);
+    res = currTask.Return();
+    currTask.DoStop();
+    
+    // not needed because user stack not used here
+    // CPULocal::SetUserStack(pt.rsp);
+    
+    // TODO not implemented?
+    // CPULocal::SetKernelStack(currTask.GetKernelSp());
+    // currTask.AccountTaskEnter(SchedState::RunningApp);
+    // currTask.RestoreFp();
+
+    if debugLevel > DebugLevel::Error {
+        let gap = if self::SHARESPACE.config.read().PerfDebug {
+            TSC.Rdtsc() - startTime
+        } else {
+            0
+        };
+        info!(
+            "({}/{})------Return[{}] res is {:x}: call id {:?} ",
+            tid,
+            pid,
+            Scale(gap),
+            res,
+            callId
+        );
+    }
+
+    CPULocal::Myself().SetEnterAppTimestamp(TSC.Rdtsc());
+    CPULocal::Myself().SetMode(VcpuMode::User);
+    currTask.mm.HandleTlbShootdown();
+    return res;
 }
 
 #[inline]
@@ -482,7 +590,15 @@ pub extern "C" fn rust_main(
 
     SHARESPACE.IncrVcpuSearching();
     taskMgr::AddNewCpu();
-    RegisterSysCall(syscall_entry as u64);
+
+    #[cfg(target_arch="x86_64")]{
+        RegisterSysCall(syscall_entry as u64);
+    }
+
+    #[cfg(target_arch="aarch64")]{
+        RegisterExceptionTable(vector_table as u64);
+    }
+
 
     //interrupts::init_idt();
     interrupt::init();

--- a/qlib/kernel/arch/aarch64/exception.s
+++ b/qlib/kernel/arch/aarch64/exception.s
@@ -1,0 +1,266 @@
+// VBAR should be set to &vector_table during kernel setup
+.globl vector_table
+// handlers defined in exception.rs
+.extern exception_handler_unhandled
+
+.extern exception_handler_el0_sync
+.extern exception_handler_el0_irq
+.extern exception_handler_el0_fiq
+.extern exception_handler_el0_serror
+
+.extern exception_handler_el1h_sync
+.extern exception_handler_el1h_irq
+.extern exception_handler_el1h_fiq
+.extern exception_handler_el1h_serror
+
+// trapframe i.e. PtRegs:
+//
+//        low                                                          high
+// -----------------------------------------------------------------------------
+// REGS   | x0 x1 x2 ... x29 x30| sp_elx | elr_el1 | spsr_el1| x0      |zero
+// -------+---------------------+--------+---------+---------+---------+--------
+// PtRegs | ----regs[31]--------| sp     | pc      | pstate  | orig_x0 |__pad
+// -----------------------------------------------------------------------------
+
+.macro save_ptregs elx
+    sub sp, sp, #288
+    stp x0, x1, [sp, #16 * 0]
+    stp x2, x3, [sp, #16 * 1]
+    stp x4, x5, [sp, #16 * 2]
+    stp x6, x7, [sp, #16 * 3]
+    stp x8, x9, [sp, #16 * 4]
+    stp x10, x11, [sp, #16 * 5]
+    stp x12, x13, [sp, #16 * 6]
+    stp x14, x15, [sp, #16 * 7]
+    stp x16, x17, [sp, #16 * 8]
+    stp x18, x19, [sp, #16 * 9]
+    stp x20, x21, [sp, #16 * 10]
+    stp x22, x23, [sp, #16 * 11]
+    stp x24, x25, [sp, #16 * 12]
+    stp x26, x27, [sp, #16 * 13]
+    stp x28, x29, [sp, #16 * 14]
+.if \elx == 0
+    mrs x9, sp_el0;
+.else
+    add x9, sp, #288
+.endif
+    mrs x10, elr_el1
+    mrs x11, spsr_el1
+    stp x30, x9, [sp, #16 * 15]
+    stp x10, x11,[sp, #16 * 16]
+    stp x0, xzr, [sp, #16 * 17]
+.endm
+
+// TODO may need to disable/enable interrupts
+.macro restore_ptregs elx
+    ldp x10, x11, [sp, #16 * 16]
+    ldp x30, x9,  [sp, #16 * 15]
+    msr elr_el1, x10
+    msr spsr_el1, x11
+.if elx == 0
+    msr sp_el0, x9
+.endif
+
+    ldp x0, x1, [sp, #16 * 0]
+    ldp x2, x3, [sp, #16 * 1]
+    ldp x4, x5, [sp, #16 * 2]
+    ldp x6, x7, [sp, #16 * 3]
+    ldp x8, x9, [sp, #16 * 4]
+    ldp x10, x11, [sp, #16 * 5]
+    ldp x12, x13, [sp, #16 * 6]
+    ldp x14, x15, [sp, #16 * 7]
+    ldp x16, x17, [sp, #16 * 8]
+    ldp x18, x19, [sp, #16 * 9]
+    ldp x20, x21, [sp, #16 * 10]
+    ldp x22, x23, [sp, #16 * 11]
+    ldp x24, x25, [sp, #16 * 12]
+    ldp x26, x27, [sp, #16 * 13]
+    ldp x28, x29, [sp, #16 * 14]
+
+    add sp, sp, #288    // reset sp_el1
+.endm
+
+
+.macro save_regs elx
+    stp x30, xzr, [sp, #-16]!
+    stp x28, x29, [sp, #-16]!
+    stp x26, x27, [sp, #-16]!
+    stp x24, x25, [sp, #-16]!
+    stp x22, x23, [sp, #-16]!
+    stp x20, x21, [sp, #-16]!
+    stp x18, x19, [sp, #-16]!
+    stp x16, x17, [sp, #-16]!
+    stp x14, x15, [sp, #-16]!
+    stp x12, x13, [sp, #-16]!
+    stp x10, x11, [sp, #-16]!
+    stp x7, x9, [sp, #-16]!
+    stp x6, x7, [sp, #-16]!
+    stp x4, x5, [sp, #-16]!
+    stp x2, x3, [sp, #-16]!
+    stp x0, x1, [sp, #-16]!
+    mrs x9, tpidr_el0
+    mrs x10, esr_el1
+    mrs x11, elr_el1
+    mrs x12, spsr_el1
+.if \elx == 0
+    mrs x13, sp_el0
+.else
+    // save the "old" value of sp_el1
+    // i.e. the value before pushing Xn
+    add x13, sp, #16 * 16
+.endif
+    stp x9, x10, [sp, #-16]!
+    stp x11, x12, [sp, #-16]!
+    stp xzr, x13, [sp, #-16]!
+.endm
+
+.macro restore_regs elx
+    ldp xzr, x13, [sp], #16
+    ldp x11, x12, [sp], #16
+    ldp x9, x10, [sp], #16
+.if elx == 0
+    msr sp_el0, x13
+    // no need to restore sp_el1 from the trap frame.
+    // popping out the frame does effectively the same
+.endif
+    msr elr_el1, x11
+    msr spsr_el1, x12
+    msr esr_el1, x10
+    msr tpidr_el0, x9
+    ldp x0, x1, [sp], #16
+    ldp x2, x1, [sp], #16
+    ldp x4, x1, [sp], #16
+    ldp x6, x1, [sp], #16
+    ldp x8, x1, [sp], #16
+    ldp x10, x1, [sp], #16
+    ldp x12, x1, [sp], #16
+    ldp x14, x1, [sp], #16
+    ldp x16, x1, [sp], #16
+    ldp x18, x1, [sp], #16
+    ldp x20, x1, [sp], #16
+    ldp x22, x1, [sp], #16
+    ldp x24, x1, [sp], #16
+    ldp x26, x1, [sp], #16
+    ldp x28, x1, [sp], #16
+    ldp x30, xzr, [sp], #16
+.endm
+
+// mitigaton of specter bhi see
+// TODO insert mitigation to the handler flow if the exception is taken
+// from EL0
+// https://documentation-service.arm.com/static/623c60d13b9f553dde8fd8e6?token=
+// Another mitigation is do_ast upon returning to user.
+.macro spectre_bhb_loop cnt
+    mov x0, #\cnt
+1:
+    b pc + 4
+    subs x18, x18, #1
+    bne 1b
+    dsb nsh
+    isb
+.endm
+
+enter_el1h_sync:
+    save_regs 1
+    mov x0, sp
+    bl exception_handler_el1h_sync
+    restore_regs 1
+    eret
+
+enter_el1h_irq:
+    save_regs 1
+    mov x0, sp
+    bl exception_handler_el1h_irq
+    restore_regs 1
+    eret
+
+enter_el1h_fiq:
+    save_regs 1
+    mov x0, sp
+    bl exception_handler_el1h_fiq
+    restore_regs 1
+    eret
+
+enter_el1h_serror:
+    save_regs 1
+    mov x0, sp
+    bl exception_handler_el1h_serror
+    restore_regs 1
+    eret
+
+enter_el0_sync:
+    save_regs 0
+    mov x0, sp
+    bl exception_handler_el0_sync
+    restore_regs 0
+    eret
+
+enter_el0_irq:
+    save_regs 0
+    mov x0, sp
+    bl exception_handler_el0_irq
+    restore_regs 0
+    eret
+
+enter_el0_fiq:
+    save_regs 0
+    mov x0, sp
+    bl exception_handler_el0_fiq
+    restore_regs 0
+    eret
+
+enter_el0_serror:
+    save_regs 0
+    mov x0, sp
+    bl exception_handler_el0_serror
+    restore_regs 0
+    eret
+
+
+// this should be more sophisticated e.g. causing
+// exception with brk. But for now we simply cause a panic
+// without saving/restoring the registers
+.macro v_empty, elx, type
+.align 7
+    mov x0, #0
+    mov x1, #\type
+    bl exception_handler_unhandled
+    eret
+.endm
+
+.macro v_entry elx handler
+.align 7
+    b \handler
+.endm
+
+
+
+.align 11
+.globl vector_table
+.type vector_table STT_FUNC
+vector_table:
+// for v_empty entries the handler parameter is instead the vector offset.
+//          ELx    Handler
+v_empty     1      0
+v_empty     1      1
+v_empty     1      2
+v_empty     1      3
+
+// interrupts are currently masked kernel
+v_entry     1      enter_el1h_sync
+v_empty     1      5
+v_empty     1      6
+v_empty     1      7
+
+v_entry     0      enter_el0_sync
+v_entry     0      enter_el0_irq
+v_entry     0      enter_el0_fiq
+v_entry     0      enter_el0_serror
+
+// 32bit state is not used
+v_empty     0     12
+v_empty     0     13
+v_empty     0     14
+v_empty     0     15
+
+// END exception vector table

--- a/qlib/kernel/arch/aarch64/syscall_entry.s
+++ b/qlib/kernel/arch/aarch64/syscall_entry.s
@@ -1,8 +1,10 @@
-.globl syscall_entry, CopyPageUnsafe
+.globl CopyPageUnsafe
 .globl context_swap, __vsyscall_page
 
-syscall_entry:
-    ret
+// For aarch64 this file does not serve as the actuall syscall entry
+// The actuall syscall is caused by SVC exception and the entry is vector_table
+// with offset 0x200, see exception.s and exception.rs
+// TODO rename this file
 __vsyscall_page:
 CopyPageUnsafe:
     ret

--- a/qlib/kernel/vcpu.rs
+++ b/qlib/kernel/vcpu.rs
@@ -14,6 +14,7 @@
 
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
+use core::arch::asm;
 
 use super::asm::*;
 //use super::IOURING;
@@ -69,9 +70,17 @@ pub fn RegisterSysCall(addr: u64) {
     WriteMsr(MSR::MSR_LSTAR as u32, addr);
 }
 
-#[cfg(target_arch = "aarch64")]
-pub fn RegisterSysCall(addr: u64) {
+// this replaces RegisterSysCall
+#[cfg(target_arch="aarch64")]
+pub fn RegisterExceptionTable(addr: u64) {
+    unsafe{
+        asm!(
+            "MSR VBAR_EL1, {}",
+            in(reg) addr,
+            );
+    }
 }
+
 
 #[cfg(target_arch = "x86")]
 #[inline]


### PR DESCRIPTION
This PR adds the exception vector table and syscall handler.

I haven't tested this implementation (at least code compiles and runs) because we can't go to userspace yet, and only the el0->el1 exceptions are handled.

**Revision(s)**
- v1 > v2 : fixed typo, remove unnecessary `mut`
- v2 > v3: rebase against armdev with #1011  ; pass NULL as call frame pointer upon empty entry.
- v3 > v4: refined register save/restore for el0 and el1 exceptions; include sp_{el0,el1} into the frame. Renamed ExceptionStateEl1 to ExceptionFrame.

Major update (v4 > v5) :

- unified exception frame and PtRegs definitions.
- added diagnostics for data/instr aborts.
- added exception handlers for el1h_sync

small fix: fixed DFSC_ names (should be _Ln instead of _ELn)

Also please note that since we use PtRegs now (which is added in a newer PR #1027), this PR only work in combination of that one. (PtRegs for aarch64 undefined, otherwise). 

The pagefault handling is out of the scope of this PR. I suggest we merge this one first if there are no other issues.
