### PR TITLE
Armdev - Removed non-compatible flag from mmap(...) in QVisor 

### DIFF
--- a/qvisor/src/kvm_vcpu_aarch64.rs
+++ b/qvisor/src/kvm_vcpu_aarch64.rs
@@ -260,7 +260,9 @@ impl KVMVcpu {
         let data = _CNTKCTL_EL1_DEFAULT;
         self.vcpu.set_one_reg(_KVM_ARM64_REGS_CNTKCTL_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
         // cpacr_el1
-        let data = 0;
+        // NOTE: FPEN[21:20] - Do not cause instructions related
+        //                     to FP registers to be trapped.
+        let data = (3 << 20);
         self.vcpu.set_one_reg(_KVM_ARM64_REGS_CPACR_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
         // sctlr_el1
         let data = _SCTLR_EL1_DEFAULT;

--- a/qvisor/src/runc/runtime/vm.rs
+++ b/qvisor/src/runc/runtime/vm.rs
@@ -397,11 +397,16 @@ impl VirtualMachine {
                     std::ptr::null_mut(),
                     0x1000,
                     libc::PROT_READ | libc::PROT_WRITE,
-                    libc::MAP_SHARED | libc::MAP_FIXED | libc::MAP_ANONYMOUS,
-                    0,
-                    0,
+                    libc::MAP_SHARED | libc::MAP_ANONYMOUS,
+                    -1,
+                     0,
                 )
             };
+
+            if mem == libc::MAP_FAILED {
+                panic!("VMM: Failed to map area for MMIO, error - {}", std::io::Error::last_os_error());
+            }
+
             let mem_region = kvm_userspace_memory_region {
                 slot: 2,
                 guest_phys_addr: MemoryDef::HYPERCALL_MMIO_BASE,


### PR DESCRIPTION
In "qvisor/(SOME_LONG_PATH)/runtime/vm.rs", the _MAP_FIXED_ flag in ```mmap(addr, ..., MAP_FIXED ...)``` causes _mmap_ to take the _addr_ parameter as fact, which in this call is ```std::ptr::null_mut()```, leading in undesired behavior. The mapping is not related to an opened file, _fd = -1_.

Late addition, fixed initialization of CPACR_EL1 register, related to FP-functionality.  