### PR TITLE
aarch64：distinguish between x86 and aarch64 for the definition of LibcStat

### DIFF
--- a/qlib/kernel/fs/host/util.rs
+++ b/qlib/kernel/fs/host/util.rs
@@ -185,12 +185,15 @@ impl LibcStat {
         ));*/
 
         let (major, minor) = DecodeDeviceId(self.st_rdev as u32);
-
+        #[cfg(target_arch = "aarch64")]
+        let st_blksize = self.st_blksize as i64;
+        #[cfg(target_arch = "x86_64")]
+        let st_blksize = self.st_blksize;
         return StableAttr {
             Type: self.InodeType(),
             DeviceId: deviceId,
             InodeId: InodeId,
-            BlockSize: self.st_blksize,
+            BlockSize: st_blksize,
             DeviceFileMajor: major,
             DeviceFileMinor: minor,
         };
@@ -235,6 +238,10 @@ impl LibcStat {
     }
 
     pub fn UnstableAttr(&self, mo: &Arc<QMutex<MountSourceOperations>>) -> UnstableAttr {
+        #[cfg(target_arch = "aarch64")]
+        let st_nlink = self.st_nlink as u64;
+        #[cfg(target_arch = "x86_64")]
+        let st_nlink = self.st_nlink;
         return UnstableAttr {
             Size: self.st_size,
             Usage: self.st_blocks * 512,
@@ -243,7 +250,7 @@ impl LibcStat {
             AccessTime: Time::FromUnix(self.st_atime, self.st_atime_nsec),
             ModificationTime: Time::FromUnix(self.st_mtime, self.st_mtime_nsec),
             StatusChangeTime: Time::FromUnix(self.st_ctime, self.st_ctime_nsec),
-            Links: self.st_nlink,
+            Links: st_nlink,
         };
     }
 }

--- a/qlib/linux_def.rs
+++ b/qlib/linux_def.rs
@@ -3243,6 +3243,7 @@ pub fn CopyPage(to: u64, from: u64) {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]
 pub struct LibcStat {
@@ -3264,6 +3265,31 @@ pub struct LibcStat {
     pub st_ctime: i64,
     pub st_ctime_nsec: i64,
     pub pad: [i64; 3],
+}
+
+#[cfg(target_arch = "aarch64")]
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct LibcStat {
+    pub st_dev: u64,
+    pub st_ino: u64,
+    pub st_mode: u32,
+    pub st_nlink: u32,
+    pub st_uid: u32,
+    pub st_gid: u32,
+    pub st_rdev: u64,
+    pub pad0: u64,
+    pub st_size: i64,
+    pub st_blksize: i32,
+    pub pad1: i32,
+    pub st_blocks: i64,
+    pub st_atime: i64,
+    pub st_atime_nsec: i64,
+    pub st_mtime: i64,
+    pub st_mtime_nsec: i64,
+    pub st_ctime: i64,
+    pub st_ctime_nsec: i64,
+    pub pad: [i32; 2],
 }
 
 impl LibcStat {


### PR DESCRIPTION
The struct definition of `stat` is slightly different in x86 and aarch64