### PR TITLE
aarch64: add functions to set/clear PAN

### DIFF
--- a/qlib/kernel/asm/aarch64.rs
+++ b/qlib/kernel/asm/aarch64.rs
@@ -639,3 +639,22 @@ pub fn spsel() -> u64 {
     }
     ret
 }
+
+// Setting or clearing the (hardware) privilege access never bit. If set, the
+// CPU will be trapped when trying to access EL0(user) memory from EL1 or above.
+// This is to prevent the kernel from accessing user memory accidentally,
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub fn SetPAN() {
+    unsafe {
+        asm!("msr PAN, #1");
+    };
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub fn ClearPAN() {
+    unsafe {
+        asm!("msr PAN, #0");
+    };
+}


### PR DESCRIPTION
add functions to set or clear the PAN bit in PSTATE.

This won't be needed until a proper copy_{to,from}_user is added.

