### PR TITLE
Fix for Docker start behavior with systemctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ sudo systemctl restart docker
 The helloworld docker sample application can be executed as below:
 ```sh
 sudo systemctl restart docker
+sudo systemctl restart docker.service
 docker run --rm --runtime=quark hello-world
 ```      
     


### PR DESCRIPTION
- Identified an issue where using 'sudo systemctl restart docker' does not always forcibly restart the 'docker.service'.
- Implemented a check to ensure that 'sudo systemctl restart docker.service' is explicitly called for a consistent restart behavior.
- This fix aims to address the inconsistent behavior observed in some cases when restarting Docker using systemctl commands.





