### PR TITLE
[RFC]VMM: adjust number of vCPUS for VM with config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,5 +27,6 @@
   "TlbShootdownWait": true,
   "Sandboxed"     : false,
   "Realtime"      : false,
-  "EnableIOBuf"   : false
+  "EnableIOBuf"   : false,
+  "LimitVMvCPUAmount": 0
 }

--- a/qlib/config.rs
+++ b/qlib/config.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::qlib::MIN_VCPU_COUNT;
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Config {
     pub DebugLevel: DebugLevel,
@@ -44,6 +46,7 @@ pub struct Config {
     pub Sandboxed: bool,
     pub Realtime: bool,
     pub EnableIOBuf: bool,
+    pub LimitVMvCPUAmount: u64,
 }
 
 impl Config {
@@ -53,6 +56,19 @@ impl Config {
 
     pub fn Async(&self) -> bool {
         return self.LogType == LogType::Async;
+    }
+
+    //
+    // The assigned value is taken in consideration
+    // if it is at least equal to the required
+    // MIN_VCPU_COUNT value.
+    //
+    pub fn get_config_vcpu_amount(&self) -> Option<usize> {
+       if self.LimitVMvCPUAmount < MIN_VCPU_COUNT as u64 {
+            None
+       } else {
+            Some(self.LimitVMvCPUAmount as usize)
+       }
     }
 }
 
@@ -90,6 +106,7 @@ impl Default for Config {
             Sandboxed: false,
             Realtime: false,
             EnableIOBuf: false,
+            LimitVMvCPUAmount: 0
         };
     }
 }

--- a/qlib/mod.rs
+++ b/qlib/mod.rs
@@ -154,6 +154,7 @@ pub const HYPERCALL_RELEASE_VCPU: u16 = 24;
 pub const DUMMY_TASKID: TaskId = TaskId::New(0xffff_ffff);
 
 pub const MAX_VCPU_COUNT: usize = 64;
+pub const MIN_VCPU_COUNT: usize = 2;
 
 #[cfg(target_arch = "x86_64")]
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
Enable configuring the amount of VM's vCPUs from Quark's configuration file. This could be useful especially during development when we want minimal setups. 