### PR TITLE
armdev: cleanup page mapping

### DIFF
--- a/qlib/addr.rs
+++ b/qlib/addr.rs
@@ -62,14 +62,14 @@ impl AccessType {
 
     #[cfg(target_arch = "aarch64")]
     pub fn NewFromPageFlags(flags: PageTableFlags) -> Self {
-        let present: bool = flags & PageTableFlags::VALID == PageTableFlags::VALID;
-        let useraccess = flags & PageTableFlags::USER_ACCESSIBLE == PageTableFlags::USER_ACCESSIBLE;
+        let present = flags.contains(PageTableFlags::VALID);
+        let useraccess = flags.contains(PageTableFlags::USER_ACCESSIBLE);
         if !present || !useraccess {
             return Self::New(false, false, false);
         }
+        let write = !flags.contains(PageTableFlags::READ_ONLY);
+        let exec = !flags.contains(PageTableFlags::UXN);
 
-        let write = flags & !PageTableFlags::READ_ONLY != PageTableFlags::READ_ONLY;
-        let exec = flags & !PageTableFlags::UXN != PageTableFlags::UXN;
         return Self::New(present, write, exec);
     }
 
@@ -246,8 +246,9 @@ pub struct PageOpts(PageTableFlags);
 #[cfg(target_arch = "aarch64")]
 impl PageOpts {
     //const Empty : PageTableFlags = PageTableFlags::PRESENT & PageTableFlags::WRITABLE; //set 0
+
     pub fn New(user: bool, write: bool, exec: bool) -> Self {
-        let mut flags = PageTableFlags::VALID | PageTableFlags::MEM_NORMAL | PageTableFlags::ACCESSED;
+        let mut flags = PageTableFlags::VALID | PageTableFlags::MT_NORMAL | PageTableFlags::ACCESSED;
         if !write {
             flags |= PageTableFlags::READ_ONLY;
         }
@@ -336,11 +337,16 @@ impl PageOpts {
         self.0 &= !PageTableFlags::NON_GLOBAL;
         return self;
     }
-	
-	// Set a collection of PT flags to configure 
+
+	// Set a collection of PT flags to configure
 	// device memory for MMIO.
-    pub fn SetDeviceMMIO(&mut self) -> &mut Self {
-        self.0 |= PageTableFlags::DEVICE_FLAGS;
+    pub fn SetMMIOPage(&mut self) -> &mut Self {
+        self.0 |= PageTableFlags::MT_NORMAL_NC |
+                  PageTableFlags::VALID |
+                  PageTableFlags::PAGE |
+                  PageTableFlags::INNER_SHAREABLE |
+                  PageTableFlags::UXN |
+                  PageTableFlags::PXN;
         return self;
     }
 
@@ -350,8 +356,7 @@ impl PageOpts {
     }
 
     pub fn SetMtNormal(&mut self) -> &mut Self {
-        self.0 &= !PageTableFlags::MEM_DEVICE;
-        self.0 |= PageTableFlags::MEM_NORMAL;
+        self.0 |= PageTableFlags::MT_NORMAL;
         return self;
     }
 

--- a/qlib/kernel/memmgr/pma.rs
+++ b/qlib/kernel/memmgr/pma.rs
@@ -268,7 +268,7 @@ impl PageTables {
         {
             let mut opts = PageOpts::Zero();
             opts.SetWrite().SetGlobal().SetPresent().SetAccessed();
-            opts.SetDeviceMMIO();
+            opts.SetMMIOPage();
             ret.MapPage(Addr(MemoryDef::HYPERCALL_MMIO_BASE),
             Addr(MemoryDef::HYPERCALL_MMIO_BASE),
             opts.Val(),

--- a/qlib/linux_def.rs
+++ b/qlib/linux_def.rs
@@ -3014,10 +3014,15 @@ impl MemoryDef {
     pub const KERNEL_START_P2_ENTRY: usize = (Self::PHY_LOWER_ADDR / Self::ONE_GB) as usize; //256
     pub const KERNEL_END_P2_ENTRY: usize = (Self::PHY_UPPER_ADDR / Self::ONE_GB) as usize; //512
                                                                                            //
-    // use 2 pages below PHY_LOWER_ADDR as MMIO base.
-    #[cfg(target_arch = "aarch64")]
-    pub const HYPERCALL_MMIO_BASE: u64 = Self::KVM_IOEVENTFD_BASEADDR - Self::PAGE_SIZE;
 }
+
+#[cfg(target_arch = "aarch64")]
+impl MemoryDef{
+    // use 2 pages below PHY_LOWER_ADDR as MMIO base.
+    pub const HYPERCALL_MMIO_BASE: u64 = Self::KVM_IOEVENTFD_BASEADDR - Self::PAGE_SIZE;
+    pub const HYPERCALL_MMIO_SIZE: u64 = 0x1000;
+}
+
 
 //mmap prot
 pub struct MmapProt {}

--- a/qvisor/src/runc/runtime/vm.rs
+++ b/qvisor/src/runc/runtime/vm.rs
@@ -357,10 +357,10 @@ impl VirtualMachine {
                 let mut opts = addr::PageOpts::Zero();
 
                 opts.SetWrite().SetGlobal().SetPresent().SetAccessed();
-                opts.SetDeviceMMIO();
+                opts.SetMMIOPage();
                 vms.KernelMap(
                     addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE),
-                    addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE + 0x1000),
+                    addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE + MemoryDef::HYPERCALL_MMIO_SIZE),
                     addr::Addr(MemoryDef::HYPERCALL_MMIO_BASE),
                     opts.Val(),
                 )?;

--- a/qvisor/src/runc/runtime/vm.rs
+++ b/qvisor/src/runc/runtime/vm.rs
@@ -393,40 +393,6 @@ impl VirtualMachine {
             heapStartAddr
         );
 
-        #[cfg(target_arch = "aarch64")]
-        {
-
-            let mem = unsafe {
-                libc::mmap(
-                    std::ptr::null_mut(),
-                    0x1000,
-                    libc::PROT_READ | libc::PROT_WRITE,
-                    libc::MAP_SHARED | libc::MAP_ANONYMOUS,
-                    -1,
-                     0,
-                )
-            };
-
-            if mem == libc::MAP_FAILED {
-                panic!("VMM: Failed to map area for MMIO, error - {}", std::io::Error::last_os_error());
-            }
-
-            let mem_region = kvm_userspace_memory_region {
-                slot: 2,
-                guest_phys_addr: MemoryDef::HYPERCALL_MMIO_BASE,
-                memory_size: 0x1000,
-                userspace_addr: mem as u64,
-                flags: 0x1 << 1,
-            };
-    
-            unsafe {
-                vm_fd
-                    .set_user_memory_region(mem_region)
-                    .map_err(|e| Error::IOError(format!("io::error is {:?}", e)))?;
-            }
-    
-        }
-
         {
             super::super::super::URING_MGR.lock();
         }


### PR DESCRIPTION
1. no longer map MMIO mem regions in the host side
2. clean up the definition of PageTableFlags, improve bitops syntax
3. ~more verbose debug info during PF~
4. ~add function to dump all valid pagetables~

**Note on merge yet** : will be rebased after #1034 

