### PR TITLE
aarch64: account task leave in exception handler

### DIFF
--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -1,6 +1,8 @@
 use super::super::syscall_dispatch_aarch64;
 use crate::qlib::linux_def::MmapProt;
 use crate::qlib::addr::AccessType;
+use crate::qlib::kernel::task;
+use crate::qlib::kernel::threadmgr::task_sched::SchedState;
 use crate::qlib::kernel::SignalDef::PtRegs;
 pub unsafe fn InitSingleton() {
 }
@@ -217,6 +219,8 @@ pub extern "C" fn exception_handler_el1h_serror(ptregs_addr:usize){
 // TODO implement el0_64_sync handler for syscalls
 #[no_mangle]
 pub extern "C" fn exception_handler_el0_sync(ptregs_addr:usize){
+    let currTask = task::Task::Current();
+    currTask.AccountTaskLeave(SchedState::RunningApp);
     let esr = GetEsrEL1();
     let ec = EsrDefs::GetExceptionFromESR(esr);
     if ptregs_addr == 0 {

--- a/qkernel/src/lib.rs
+++ b/qkernel/src/lib.rs
@@ -349,7 +349,7 @@ pub fn syscall_dispatch_aarch64(
     CPULocal::Myself().SetMode(VcpuMode::Kernel);
 
     let currTask = task::Task::Current();
-    currTask.AccountTaskLeave(SchedState::RunningApp);
+    // No AccountTaskLeave here because it's called already in the exception handler
 
     let mut nr = call_no as u64;
 
@@ -409,10 +409,8 @@ pub fn syscall_dispatch_aarch64(
     MainRun(currTask, state);
     res = currTask.Return();
     currTask.DoStop();
-    
     // not needed because user stack not used here
     // CPULocal::SetUserStack(pt.rsp);
-    
     // TODO not implemented?
     // CPULocal::SetKernelStack(currTask.GetKernelSp());
     // currTask.AccountTaskEnter(SchedState::RunningApp);


### PR DESCRIPTION
quick bug fix: the exception handler (sync_el0) should set the task state to kernel.