### PR TITLE
aarch64: control accessing user mem from EL1

### DIFF
--- a/qkernel/src/kernel_def.rs
+++ b/qkernel/src/kernel_def.rs
@@ -49,6 +49,7 @@ use super::qlib::*;
 use super::syscalls::sys_file::*;
 use super::Kernel::HostSpace;
 
+
 use crate::GLOBAL_ALLOCATOR;
 
 impl IoUring {
@@ -512,4 +513,33 @@ pub fn IsKernel() -> bool {
 
 pub fn ReapSwapIn() {
     HostSpace::SwapIn();
+}
+
+/// enable access to EL0 memory from EL1 return the previous state
+/// true : enabled, false : disabled
+#[inline]
+pub fn enable_access_user() -> bool {
+    #[cfg(target_feature = "pan")]
+    {
+        unsafe {
+            // PAN==1 means access NOT allowed
+            let allow = !pan();
+            pan_set(false);
+            return allow;
+        }
+    }
+    // if PAN is not the case, accessing user memory is always enabled for EL1
+    return true;
+}
+
+/// reset access to EL0 memory from EL1 return the previous state
+/// true : enable false : disable
+#[inline]
+pub fn set_access_user(allow: bool) {
+    #[cfg(target_feature = "pan")]
+    {
+        unsafe {
+            pan_set(!allow);
+        }
+    }
 }

--- a/qlib/kernel/asm/aarch64.rs
+++ b/qlib/kernel/asm/aarch64.rs
@@ -689,3 +689,21 @@ pub fn spsel() -> u64 {
     }
     ret
 }
+
+#[inline]
+#[target_feature(enable = "pan")]
+pub unsafe fn pan() -> bool {
+    let pan: u64;
+    asm !("mrs {0}, pan", out(reg) pan);
+    return pan != 0;
+}
+
+#[inline]
+#[target_feature(enable = "pan")]
+pub unsafe fn pan_set(val: bool) {
+    if val {
+        asm!("msr pan, #1");
+    }else {
+        asm!("msr pan, #0");
+    }
+}


### PR DESCRIPTION
by setting and unsetting PAN (when feature supported). To enable cpu feature, add "+pan" in the features (aarch64-qkernel.json). Otherwise the enable_access_user() and set_access_user() simply return.