### PR TITLE
aarch64: save tls when leaving el0

### DIFF
--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -236,6 +236,7 @@ pub extern "C" fn exception_handler_el1h_serror(ptregs_addr:usize){
 pub extern "C" fn exception_handler_el0_sync(ptregs_addr:usize){
     let currTask = task::Task::Current();
     currTask.AccountTaskLeave(SchedState::RunningApp);
+    currTask.SaveTLS();
     let esr = GetEsrEL1();
     let ec = EsrDefs::GetExceptionFromESR(esr);
     if ptregs_addr == 0 {

--- a/qlib/kernel/task.rs
+++ b/qlib/kernel/task.rs
@@ -862,6 +862,12 @@ impl Task {
         SetTLS(self.context.tls);
     }
 
+    #[cfg(target_arch="aarch64")]
+    #[inline]
+    pub fn SaveTLS(&mut self) {
+        self.context.tls = tpidr_el0();
+    }
+
     #[inline]
     pub fn GetContext(&self) -> u64 {
         return (&self.context as *const Context) as u64;


### PR DESCRIPTION
Save tpidr_el0 to task.context.tls when leaving EL0.

Fixes #1091 