### PR TITLE
aarch64: add debug context for UnknownException in EL0

### DIFF
--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -274,7 +274,14 @@ pub extern "C" fn exception_handler_el0_sync(ptregs_addr: usize) {
                 ctx.pc += 4;
             }
             _ => {
-                panic!("unhandled sync exception from el0: {},\ncan't emulate mrs\n current-context: {:?}", ec, ctx);
+                unsafe {
+                     if let Some(opcode) = kernel_def::read_user_opcode(ctx.pc) {
+                         debug!("VM: UNKNOWN_EXCEPTION from EL0, current-PC: {:#x}, retrieved PC[opcode]:{:#x}.", ctx.pc, opcode);
+                     } else {
+                         debug!("VM: UNKNOWN_EXCEPTION from EL0, current-PC: {:#x}, can not retrieve PC[opcode].", ctx.pc);
+                     }
+                }
+                panic!("VM: panic on UNKNOWN_EXCEPTION from EL0 - current-context: {:?}", ctx);
             }
         },
         _ => {


### PR DESCRIPTION
In case some legal _mrs_-instruction did not cause the exception, log the PC and, if possible, the opcode before panic. 