### PR TITLE
aarch64: include HYPERCALL_MMIO in Kernel memory-space.

### DIFF
--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -22,6 +22,7 @@ use crate::qlib::kernel::task;
 use crate::qlib::kernel::threadmgr::task_sched::SchedState;
 use crate::qlib::kernel::SignalDef::PtRegs;
 use crate::qlib::vcpu_mgr::*;
+use crate::kernel_def;
 use self::fault::{PageFaultHandler, PageFaultErrorCode};
 
 pub unsafe fn InitSingleton() {


### PR DESCRIPTION
In aarch64, we use an extra page below the _KVM_IOEVENTFD_BASEADDR_ page for Hypercalls, _HYPERCALL_MMIO_BASE_. Till now, we have missed including it in the memory management bookkeeping. 