### PR TITLE
aarch64: fix mprotect syscall

### DIFF
--- a/qlib/addr.rs
+++ b/qlib/addr.rs
@@ -282,25 +282,34 @@ impl PageOpts {
     }
 
     pub fn UserReadOnly() -> Self {
-        return PageOpts(PageTableFlags::VALID | PageTableFlags::USER_ACCESSIBLE | PageTableFlags::READ_ONLY);
+        return PageOpts(
+            PageTableFlags::VALID |
+            PageTableFlags::USER_ACCESSIBLE |
+            PageTableFlags::READ_ONLY |
+            PageTableFlags::MT_NORMAL |
+            PageTableFlags::ACCESSED
+        );
     }
 
     pub fn UserNonAccessable() -> Self {
-        return PageOpts(PageTableFlags::VALID | PageTableFlags::ACCESSED);
+        return PageOpts(PageTableFlags::VALID | PageTableFlags::ACCESSED | PageTableFlags::MT_NORMAL);
     }
 
     pub fn UserReadWrite() -> Self {
         return PageOpts(
-            PageTableFlags::VALID | PageTableFlags::USER_ACCESSIBLE,
+            PageTableFlags::VALID |
+            PageTableFlags::USER_ACCESSIBLE |
+            PageTableFlags::MT_NORMAL |
+            PageTableFlags::ACCESSED
         );
     }
 
     pub fn KernelReadOnly() -> Self {
-        return PageOpts(PageTableFlags::VALID | PageTableFlags::READ_ONLY);
+        return PageOpts(PageTableFlags::VALID | PageTableFlags::READ_ONLY | PageTableFlags::MT_NORMAL | PageTableFlags::ACCESSED);
     }
     
     pub fn KernelReadWrite() -> Self {
-        return PageOpts(PageTableFlags::VALID);
+        return PageOpts(PageTableFlags::VALID | PageTableFlags::MT_NORMAL | PageTableFlags::ACCESSED);
     }
 
     pub fn Present(&self) -> bool {


### PR DESCRIPTION
sys_mprotect will reset the page flag, but currently the UserNonAccessable/UserReadOnly/UserReadWrite definition is missing the MT_NORMAL, this will cause a pagefault of the installed page, and we will install another page.