### PR TITLE
aarch64: do not set a x86_64 hwcap to auxv

### DIFF
--- a/qlib/kernel/loader/loader.rs
+++ b/qlib/kernel/loader/loader.rs
@@ -386,6 +386,7 @@ pub fn SetupUserStack(
         Key: AuxVec::AT_PAGESZ,
         Val: 4096,
     });
+    #[cfg(target_arch = "x86_64")]
     auxv.push(AuxEntry {
         Key: AuxVec::AT_HWCAP,
         Val: 0xbfebfbff,


### PR DESCRIPTION
otherwise libc may call some instructions based on the hwcap and make a UNKNOWN_EXCAPTTION