### PR TITLE
Armdev syscall id table consistent

### DIFF
--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -222,16 +222,16 @@ pub extern "C" fn exception_handler_el1h_sync(ptregs_addr:usize){
                 let ctx_p = ctx_p.cast::<PtRegs>();
                 let ctx = unsafe { &mut *ctx_p };
                 unsafe {
-                     if let Some(opcode) = kernel_def::read_user_opcode(ctx.pc) {
-                         debug!("VM: current-PC: {:#x}, retrieved PC[opcode]:{:#x}.", ctx.pc, opcode);
-                     } else {
-                         debug!("VM: current-PC: {:#x}, can not retrieve PC[opcode].", ctx.pc);
-                     }
+                    if let Some(opcode) = kernel_def::read_user_opcode(ctx.pc) {
+                        debug!("VM: current-PC: {:#x}, retrieved PC[opcode]:{:#x}.", ctx.pc, opcode);
+                    } else {
+                        debug!("VM: current-PC: {:#x}, can not retrieve PC[opcode].", ctx.pc);
+                    }
                 }
             }
             panic!("VM: exit on panic.");
         }
-     }
+    }
 }
 
 #[no_mangle]

--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -202,6 +202,7 @@ pub extern "C" fn exception_handler_unhandled(_ptregs_addr:usize, exception_type
 pub extern "C" fn exception_handler_el1h_sync(ptregs_addr:usize){
     let esr = GetEsrEL1();
     let ec = EsrDefs::GetExceptionFromESR(esr);
+    kernel_def::enable_access_user();
 
     match ec {
         EsrDefs::EC_DATA_ABORT => {
@@ -213,9 +214,24 @@ pub extern "C" fn exception_handler_el1h_sync(ptregs_addr:usize){
             MemAbortKernel(ptregs_addr, esr, far, true);
         },
         _ => {
-            panic!("unhandled sync exception from el1: {}\n", ec);
+            debug!("unhandled sync exception from el1: {:#x}\n - ESR_EL1:{:#x}", ec, esr);
+            if ptregs_addr == 0 {
+               panic!("VM: exception frame is null pointer\n")
+            } else {
+                let ctx_p = ptregs_addr as *mut PtRegs;
+                let ctx_p = ctx_p.cast::<PtRegs>();
+                let ctx = unsafe { &mut *ctx_p };
+                unsafe {
+                     if let Some(opcode) = kernel_def::read_user_opcode(ctx.pc) {
+                         debug!("VM: current-PC: {:#x}, retrieved PC[opcode]:{:#x}.", ctx.pc, opcode);
+                     } else {
+                         debug!("VM: current-PC: {:#x}, can not retrieve PC[opcode].", ctx.pc);
+                     }
+                }
+            }
+            panic!("VM: exit on panic.");
         }
-    }
+     }
 }
 
 #[no_mangle]

--- a/qkernel/src/syscalls/syscalls.rs
+++ b/qkernel/src/syscalls/syscalls.rs
@@ -1037,7 +1037,7 @@ pub const SYS_CALL_TABLE: &'static [SyscallFn] = &[
     NotImplementSyscall,  //	436
     NotImplementSyscall,  //	437
     NotImplementSyscall,  //	438
-    NotImplementSyscall,  //	439
+    SysNoSys,             //	439
     NotImplementSyscall,  //	440
     NotImplementSyscall,  //	441
     NotImplementSyscall,  //	442

--- a/qlib/mod.rs
+++ b/qlib/mod.rs
@@ -992,7 +992,6 @@ pub enum SysCallID {
     // 330
     syscall_331,
     syscall_332,
-
     syscall_333,
     syscall_334,
     syscall_335,
@@ -1001,6 +1000,7 @@ pub enum SysCallID {
     syscall_338,
     syscall_339,
     syscall_340,
+    // 340
     syscall_341,
     syscall_342,
     syscall_343,
@@ -1011,6 +1011,7 @@ pub enum SysCallID {
     syscall_348,
     syscall_349,
     syscall_350,
+    // 350
     syscall_351,
     syscall_352,
     syscall_353,
@@ -1021,6 +1022,7 @@ pub enum SysCallID {
     syscall_358,
     syscall_359,
     syscall_360,
+    // 360
     syscall_361,
     syscall_362,
     syscall_363,
@@ -1031,6 +1033,7 @@ pub enum SysCallID {
     syscall_368,
     syscall_369,
     syscall_370,
+    // 371
     syscall_371,
     syscall_372,
     syscall_373,
@@ -1041,6 +1044,7 @@ pub enum SysCallID {
     syscall_378,
     syscall_379,
     syscall_380,
+    // 380
     syscall_381,
     syscall_382,
     syscall_383,
@@ -1051,6 +1055,7 @@ pub enum SysCallID {
     syscall_388,
     syscall_389,
     syscall_390,
+    // 390
     syscall_391,
     syscall_392,
     syscall_393,
@@ -1061,6 +1066,7 @@ pub enum SysCallID {
     syscall_398,
     syscall_399,
     syscall_400,
+    // 400
     syscall_401,
     syscall_402,
     syscall_403,
@@ -1071,6 +1077,7 @@ pub enum SysCallID {
     syscall_408,
     syscall_409,
     syscall_410,
+    // 410
     syscall_411,
     syscall_412,
     syscall_413,
@@ -1081,10 +1088,41 @@ pub enum SysCallID {
     syscall_418,
     syscall_419,
     syscall_420,
+    //420
     syscall_421,
     syscall_422,
     syscall_423,
-   
+    syscall_424,
+    syscall_425,
+    syscall_426,
+    syscall_427,
+    syscall_428,
+    syscall_429,
+    syscall_430,
+    // 430
+    syscall_431,
+    syscall_432,
+    syscall_433,
+    syscall_434,
+    syscall_435,
+    syscall_436,
+    syscall_437,
+    syscall_438,
+    syscall_439,
+    syscall_440,
+    // 440
+    syscall_441,
+    syscall_442,
+    syscall_443,
+    syscall_444,
+    syscall_445,
+    syscall_446,
+    syscall_447,
+    syscall_448,
+    syscall_449,
+    syscall_450,
+    // No Valid syscall number
+
     UnknowSyscall = 451,
 
     EXTENSION_MAX,


### PR DESCRIPTION
Related to #1161
+ 550dbd88c4bef21e444482dc7639db4e16691bee makes the syscall-number validity [check](https://github.com/QuarkContainer/Quark/blob/bf8725fde4ba3e2271a8ca83da0475f3ecdb2658/qkernel/src/lib.rs#L382) consistent.
+ 61336b29328fa14ee2e8b672482fffd1349ee93b produces helpful log information.
+ c122ccb38060d3f03b20332234b03c2e90460cf4 aqv. of linux sys_ni_syscall.

Regarding #1161, it avoids hitting the breakpoint instruction; we should not get there. In the general case, it will log if a non-implemented syscall was called.