### PR TITLE
Separate cuda build from non cuda machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ And also install "cargo-xbuild" as below.
 cargo +stable install cargo-xbuild
 ```
 
-And also some extra libraries for compiling GPU module:
+And also some extra libraries for compiling GPU module:  
+(Please note, you can execute following commands even in non nvidia machine to get ability for compiling GPU module.)
 ```sh
 sudo apt-get install libelf-dev nvidia-driver-535
 ```
@@ -82,6 +83,12 @@ sudo apt-get install libelf-dev nvidia-driver-535
 git clone git@github.com:QuarkContainer/Quark.git
 cd Quark
 make
+make install
+```
+
+### Build with GPU module
+```sh
+make cuda_all
 make install
 ```
 

--- a/makefile
+++ b/makefile
@@ -26,9 +26,11 @@ QUARK_BIN_RELEASE = $(QTARGET_RELASE)/$(QUARK)
 #
 MAKEFLAGS += -j4
 
-.PHONY: all release debug clean install qvisor_release qvisor_debug cuda_make
+.PHONY: all release debug clean install qvisor_release qvisor_debug cuda_make cuda_all
 
 all:: release debug
+
+cuda_all:: cuda_release cuda_debug
 
 release:: qvisor_release qkernel_release 
 

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ QUARK_BIN_RELEASE = $(QTARGET_RELASE)/$(QUARK)
 #
 MAKEFLAGS += -j4
 
-.PHONY: all release debug clean install qvisor_release qvisor_debug cuda
+.PHONY: all release debug clean install qvisor_release qvisor_debug cuda_make
 
 all:: release debug
 
@@ -51,6 +51,16 @@ clean:
 
 docker:
 	sudo systemctl restart docker
+
+cuda_release:: qvisor_cuda_release qkernel_release cuda_make
+
+cuda_debug:: qvisor_cuda_debug qkernel_debug cuda_make
+
+qvisor_cuda_release:
+	make -C ./qvisor cuda_release
+
+qvisor_cuda_debug:
+	make -C ./qvisor cuda_debug
 
 install:
 #
@@ -89,7 +99,7 @@ endif
 # Always Install config for debug purpose
 	sudo cp -f $(QROOT_DIR)/config.json $(QCONFIG_GLOBAL_DIR)
 
-cuda:
+cuda_make:
 	make -C $(QROOT_DIR)/cudaproxy release
 	sudo cp -f $(QTARGET_RELASE)/libcudaproxy.so $(QBIN_DIR)/libcudaproxy.so
 	sudo cp -f $(QTARGET_RELASE)/libcudaproxy.so $(QROOT_DIR)/test

--- a/qvisor/Cargo.lock
+++ b/qvisor/Cargo.lock
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"

--- a/qvisor/Cargo.toml
+++ b/qvisor/Cargo.toml
@@ -55,10 +55,13 @@ time = { version = "0.3.7", features = ["serde", "std"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 hashbrown = "0.12.3"
 enum_dispatch = { git = "https://github.com/QuarkContainer/enum_dispatch_clone.git" }
-cuda-driver-sys = "0.3.0"
-cuda-runtime-sys = "0.3.0-alpha.1"
-libelf = "0.1.0"
+cuda-driver-sys = { version = "0.3.0", optional = true }
+cuda-runtime-sys = { version = "0.3.0-alpha.1", optional = true }
+libelf = { version = "0.1.0", optional = true }
 io-uring = "0.6.3"
+
+[features]
+cuda = ["cuda-driver-sys", "cuda-runtime-sys", "libelf"]
 
 [dependencies.lazy_static]
 version = "1.4"

--- a/qvisor/makefile
+++ b/qvisor/makefile
@@ -1,8 +1,13 @@
-.PHONY: debug release
+.PHONY: debug release cuda_debug cuda_release
 
 debug:
-	CARGO_TARGET_DIR=../target cargo +nightly-2022-08-11-x86_64-unknown-linux-gnu build 
+	CARGO_TARGET_DIR=../target cargo +nightly-2022-08-11-x86_64-unknown-linux-gnu build
 
 release:
 	CARGO_TARGET_DIR=../target cargo +nightly-2022-08-11-x86_64-unknown-linux-gnu build --release
 
+cuda_debug:
+	CARGO_TARGET_DIR=../target cargo +nightly-2022-08-11-x86_64-unknown-linux-gnu build --features cuda
+
+cuda_release:
+	CARGO_TARGET_DIR=../target cargo +nightly-2022-08-11-x86_64-unknown-linux-gnu build --release --features cuda

--- a/qvisor/src/vmspace/mod.rs
+++ b/qvisor/src/vmspace/mod.rs
@@ -24,7 +24,7 @@ pub mod random;
 pub mod syscall;
 pub mod time;
 pub mod uringMgr;
-#[cfg(cuda)]
+#[cfg(feature = "cuda")]
 pub mod nvidia;
 pub mod tsot_agent;
 pub mod xpu;
@@ -56,7 +56,7 @@ use crate::vmspace::kernel::GlobalIOMgr;
 use crate::vmspace::kernel::GlobalRDMASvcCli;
 
 use self::limits::*;
-#[cfg(cuda)]
+#[cfg(feature = "cuda")]
 use self::nvidia::NvidiaProxy;
 use self::random::*;
 use self::syscall::*;
@@ -1931,7 +1931,7 @@ impl VMSpace {
     }
 
     pub fn Proxy(_cmd: ProxyCommand, _parameters: &ProxyParameters) -> i64 {
-        #[cfg(cuda)]
+        #[cfg(feature = "cuda")]        
         match NvidiaProxy(_cmd, _parameters) {
             Ok(v) => return v,
             Err(e) => {
@@ -1939,7 +1939,7 @@ impl VMSpace {
                 return 0;
             }
         }
-        #[cfg(not(cuda))]
+        #[cfg(not(feature = "cuda"))]
         return 0;
     }
 

--- a/qvisor/src/vmspace/mod.rs
+++ b/qvisor/src/vmspace/mod.rs
@@ -24,6 +24,7 @@ pub mod random;
 pub mod syscall;
 pub mod time;
 pub mod uringMgr;
+#[cfg(cuda)]
 pub mod nvidia;
 pub mod tsot_agent;
 pub mod xpu;
@@ -55,6 +56,7 @@ use crate::vmspace::kernel::GlobalIOMgr;
 use crate::vmspace::kernel::GlobalRDMASvcCli;
 
 use self::limits::*;
+#[cfg(cuda)]
 use self::nvidia::NvidiaProxy;
 use self::random::*;
 use self::syscall::*;
@@ -1928,14 +1930,17 @@ impl VMSpace {
         }
     }
 
-    pub fn Proxy(cmd: ProxyCommand, parameters: &ProxyParameters) -> i64 {
-        match NvidiaProxy(cmd, parameters) {
+    pub fn Proxy(_cmd: ProxyCommand, _parameters: &ProxyParameters) -> i64 {
+        #[cfg(cuda)]
+        match NvidiaProxy(_cmd, _parameters) {
             Ok(v) => return v,
             Err(e) => {
                 error!("nvidia proxy get error {:?}", e);
                 return 0;
             }
         }
+        #[cfg(not(cuda))]
+        return 0;
     }
 
     pub fn SwapInPage(addr: u64) -> i64 {

--- a/qvisor/src/vmspace/xpu/mod.rs
+++ b/qvisor/src/vmspace/xpu/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(cuda)]
 pub mod cuda;

--- a/qvisor/src/vmspace/xpu/mod.rs
+++ b/qvisor/src/vmspace/xpu/mod.rs
@@ -1,2 +1,2 @@
-#[cfg(cuda)]
+#[cfg(feature = "cuda")]
 pub mod cuda;


### PR DESCRIPTION
After this commit, by default make won't build cuda, so there is no cuda dependency by default. In machine with cuda library, need to do make cuda_all, (or cuda_debug, cuda_release etc) to build cuda.