### PR TITLE
aarch64: fix context switching issues

### DIFF
--- a/qlib/kernel/arch/aarch64/exception.s
+++ b/qlib/kernel/arch/aarch64/exception.s
@@ -57,7 +57,7 @@
     ldp x30, x9,  [sp, #16 * 15]
     msr elr_el1, x10
     msr spsr_el1, x11
-.if elx == 0
+.if \elx == 0
     msr sp_el0, x9
 .endif
 

--- a/qlib/pagetable.rs
+++ b/qlib/pagetable.rs
@@ -203,7 +203,7 @@ impl PageTables {
 
     #[cfg(target_arch = "aarch64")]
     pub fn Switch(table: u64) {
-        LoadUserTable(table)
+        LoadTranslationTable(table)
     }
 
     pub fn SetRoot(&self, root: u64) {

--- a/qvisor/src/kvm_vcpu_aarch64.rs
+++ b/qvisor/src/kvm_vcpu_aarch64.rs
@@ -256,7 +256,8 @@ impl KVMVcpu {
         // ttbr0_el1
         let data = VMS.lock().pageTables.GetRoot();
         self.vcpu.set_one_reg(_KVM_ARM64_REGS_TTBR0_EL1, data).map_err(|e| Error::SysError(e.errno()))?;
-        // TODO set ttbr1_el1
+        // TODO set ttbr1_el1 if we need upper half address space.
+
         // cntkctl_el1
         let data = _CNTKCTL_EL1_DEFAULT;
         self.vcpu.set_one_reg(_KVM_ARM64_REGS_CNTKCTL_EL1, data).map_err(|e| Error::SysError(e.errno()))?;


### PR DESCRIPTION
@CharlyYu may I have your Signoffs  for the first two commits? since you suggested the changes. You could also push them on your own if you prefer.

(I added `Suggested-by` commit trailers, but are not recognized by github)


This fixes the fork-wait issues we had.

1. restore userspace sp correctly
2. invalidate tlb when switching address space
3. <del> (wip) ignore some panic conditions in PF handler </del>

[The test programs](https://github.com/QuarkContainer/Quark/issues/1210#issuecomment-2091829056) work without issue.

Note: for the above testing program to work, take #1215 as well.