### PR TITLE
aarch64: refactor paging and page fault handler

### DIFF
--- a/qkernel/src/syscalls/sys_mmap.rs
+++ b/qkernel/src/syscalls/sys_mmap.rs
@@ -139,7 +139,7 @@ pub fn SysMprotect(task: &mut Task, args: &SyscallArguments) -> Result<i64> {
     let accessType = AccessType(prot);
     let growDown = prot & MmapProt::PROT_GROWSDOWN != 0;
 
-    match task.mm.MProtect(addr, len, &accessType, growDown) {
+    match task.mm.MProtect(addr, len, &accessType, growDown, true) {
         Err(e) => return Err(e),
         _ => return Ok(0),
     }

--- a/qlib/kernel/arch/aarch64/mm/pagetable.rs
+++ b/qlib/kernel/arch/aarch64/mm/pagetable.rs
@@ -100,9 +100,15 @@ impl PageTableEntry {
     //}
 
     /// Sets the flags of this entry.
+    /// TODO: Enforcing PAGE here is not an optimal fix.
     #[inline]
     pub fn set_flags(&mut self, flags: PageTableFlags) {
-        self.entry = self.addr().as_u64() | flags.bits();
+        self.entry = self.addr().as_u64() | flags.bits() | PageTableFlags::PAGE.bits();
+    }
+    /// Sets the flags of this entry but only sets permission bits.
+    #[inline]
+    pub fn set_flags_perms_only(&mut self, flags: PageTableFlags){
+        self.entry = (self.entry & !PageTableFlags::MProtectBits.bits()) | flags.bits()
     }
 }
 
@@ -158,6 +164,15 @@ bitflags! {
         const TAKEN           = 1 << 57; //Another thread is using the PTE.
     }
 }
+
+impl PageTableFlags {
+    pub const MProtectBits:PageTableFlags = PageTableFlags::from_bits_truncate(
+        PageTableFlags::USER_ACCESSIBLE.bits() |
+        PageTableFlags::READ_ONLY.bits() |
+        PageTableFlags::PXN.bits() |
+        PageTableFlags::UXN.bits());
+}
+
 
 /// The number of entries in a page table.
 const ENTRY_COUNT: usize = 512;

--- a/qlib/kernel/loader/elf.rs
+++ b/qlib/kernel/loader/elf.rs
@@ -197,6 +197,7 @@ pub fn MapSegment(
                 4096,
                 &AccessType::AnyAccess(),
                 false,
+                false
             )
             .unwrap();
         task.CopyOutSlice(&buf[0..cnt], vaddr, cnt)?;


### PR DESCRIPTION
breaking change: `MemoryManager::MProtect` function now receives another parameter `permOnly`. When passed true, the MProtect routine will NOT touch PTE flags other than permission related ones. This prevents `mprotect` from corrupting PTEs, which causes weird page faults.  Related: #1131

Ideally the `MProtect` function should NEVER touch PTE flags such as `PRESENT` or `TABLE`. This is wrong semantics. However both x86 and aarch64 code relies this to set up forked address spaces, or load new ELFs. We could do some refactoring in the future. 

On PF handling: as suggested by @QuarkContainer , we skip page swapping for now.