### PR TITLE
[wip] force SIGILL on illegal instr from EL0

### DIFF
--- a/qkernel/src/interrupt/aarch64/mod.rs
+++ b/qkernel/src/interrupt/aarch64/mod.rs
@@ -20,9 +20,11 @@ use crate::qlib::linux_def::MmapProt;
 use crate::qlib::addr::AccessType;
 use crate::qlib::kernel::task;
 use crate::qlib::kernel::threadmgr::task_sched::SchedState;
-use crate::qlib::kernel::SignalDef::PtRegs;
+use crate::qlib::kernel::SignalDef::{PtRegs, SignalInfo};
 use crate::qlib::vcpu_mgr::*;
-use crate::kernel_def;
+use crate::qlib::linux_def::Signal;
+use crate::qlib::common::TaskRunState;
+use crate::{kernel_def, MainRun};
 use self::fault::{PageFaultHandler, PageFaultErrorCode};
 
 pub unsafe fn InitSingleton() {
@@ -298,12 +300,22 @@ pub extern "C" fn exception_handler_el0_sync(ptregs_addr: usize) {
             _ => {
                 unsafe {
                      if let Some(opcode) = kernel_def::read_user_opcode(ctx.pc) {
-                         debug!("VM: UNKNOWN_EXCEPTION from EL0, current-PC: {:#x}, retrieved PC[opcode]:{:#x}.", ctx.pc, opcode);
+                         debug!("VM: UNKNOWN_EXCEPTION {} from EL0, current-PC: {:#x}, retrieved PC[opcode]:{:#x}.", ec, ctx.pc, opcode);
                      } else {
-                         debug!("VM: UNKNOWN_EXCEPTION from EL0, current-PC: {:#x}, can not retrieve PC[opcode].", ctx.pc);
+                         debug!("VM: UNKNOWN_EXCEPTION {} from EL0, current-PC: {:#x}, can not retrieve PC[opcode].", ec, ctx.pc);
                      }
                 }
-                panic!("VM: panic on UNKNOWN_EXCEPTION from EL0 - current-context: {:?}", ctx);
+
+                let mut info = SignalInfo {
+                    Signo: Signal::SIGILL,
+                    ..Default::default()
+                };
+                let thread = currTask.Thread();
+                thread.forceSignal(Signal(Signal::SIGILL), false);
+                thread
+                    .SendSignal(&info)
+                    .expect("PageFaultHandler send signal fail");
+                MainRun(currTask, TaskRunState::RunApp);
             }
         },
         _ => {


### PR DESCRIPTION
```
4 SIGILL Illegal instruction. 
The program contained some machine code the CPU can't understand.
```

some userspace program insert illegal exception and listen on (SIGILL 4). This could be some sort of software breakpoint.
e.g. nginx uses this (I don't know why .... )

Anyways, EL0 exceptions should not cause the kernel to panic. Note that this commit is not complete. (some code should be added after calling MainRun ... ) 