### PR TITLE
aarch64: fix arch specific epoll event issue

### DIFF
--- a/qkernel/src/syscalls/sys_epoll.rs
+++ b/qkernel/src/syscalls/sys_epoll.rs
@@ -260,7 +260,10 @@ pub fn SysEpollCtl(task: &mut Task, args: &SyscallArguments) -> Result<i64> {
 
 // copyOutEvents copies epoll events from the kernel to user memory.
 pub fn CopyOutEvents(task: &Task, addr: u64, e: &[Event]) -> Result<()> {
+    #[cfg(target_arch = "x86_64")]
     let itemLen: usize = 12;
+    #[cfg(target_arch = "aarch64")]
+    let itemLen: usize = 16;
 
     Addr(addr).AddLen((itemLen * e.len()) as u64)?;
 

--- a/qlib/linux_def.rs
+++ b/qlib/linux_def.rs
@@ -253,10 +253,21 @@ pub struct LibcSysinfo {
     //pub _f: [i8; 0],
 }
 
+#[cfg(target_arch = "x86_64")]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EpollEvent {
     pub Events: u32,
+    pub FD: i32,
+    pub Pad: i32,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct EpollEvent {
+    pub Events: u32,
+    pub _pad: i32,
     pub FD: i32,
     pub Pad: i32,
 }


### PR DESCRIPTION
The epoll_event defined in linux is different on aarch64 than on x86_64, on x86_64, it is __attribute__((packed)) so the size of it is 12, but on aarch64 there is no such attribute, makes its size 16, and we have to add padding between Events and the data.

With this PR, nginx could run on arm64

![image](https://github.com/QuarkContainer/Quark/assets/144826373/a1321a68-eb14-44c1-9438-0e4016939384)
