### PR TITLE
(temp) update sigret vdso offset for aarch64

### DIFF
--- a/qlib/kernel/SignalDef.rs
+++ b/qlib/kernel/SignalDef.rs
@@ -412,7 +412,7 @@ impl UContext {
 
 // HACK. TODO Refactor this as soon as we have proper VDSO perser.
 #[cfg(target_arch = "aarch64")]
-pub const VDSO_OFFSET_SIGRETURN: u64 = 0x1120;
+pub const VDSO_OFFSET_SIGRETURN: u64 = 0x1100;
 
 // https://elixir.bootlin.com/linux/latest/source/arch/x86/include/uapi/asm/sigcontext.h#L284
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
the vdso build is somehow changed and the symbol offset is different. This is a temporary fix. We should get rid of the hardcoded value by implementing a proper vdso parser.