### PR TITLE
fix random gen

### DIFF
--- a/qlib/kernel/kernel_util.rs
+++ b/qlib/kernel/kernel_util.rs
@@ -35,6 +35,6 @@ pub fn RandU64() -> Result<u64> {
 
 pub fn RandU128() -> Result<(u64, u64)> {
     let res: [u64; 2] = [0; 2];
-    Random(&res[0] as *const _ as u64, 18, GRND_RANDOM)?;
+    Random(&res[0] as *const _ as u64, 16, GRND_RANDOM)?;
     return Ok((res[0], res[1]));
 }


### PR DESCRIPTION
```
this is devil hidding in plain sight

pub fn RandU128() -> Result<(u64, u64)> {
    let res: [u64; 2] = [0; 2];
    Random(&res[0] as *const _ as u64, 18, GRND_RANDOM)?;
                                       ^^^^
                                       this is off by 2,
                                       should be 16.
    return Ok((res[0], res[1]));
}

causing a stack overrun. The behaviour is kinda random and never spotted on x86.
```