### PR TITLE
epoll: define EpollEvent structure per linux API

### DIFF
--- a/qkernel/src/syscalls/sys_epoll.rs
+++ b/qkernel/src/syscalls/sys_epoll.rs
@@ -49,7 +49,7 @@ pub fn AddEpoll(
     fd: i32,
     flags: EntryFlags,
     mask: EventMask,
-    userData: [i32; 2],
+    userData: u64
 ) -> Result<()> {
     // Get epoll from the file descriptor.
     let epollfile = task.GetFile(epfd)?;
@@ -83,7 +83,7 @@ pub fn UpdateEpoll(
     fd: i32,
     flags: EntryFlags,
     mask: EventMask,
-    userData: [i32; 2],
+    userData: u64
 ) -> Result<()> {
     // Get epoll from the file descriptor.
     let epollfile = task.GetFile(epfd)?;
@@ -219,7 +219,7 @@ pub fn SysEpollCtl(task: &mut Task, args: &SyscallArguments) -> Result<i64> {
     // Capture the event state if needed.
     let mut flags = 0;
     let mut mask = 0;
-    let mut data: [i32; 2] = [0, 0];
+    let mut data: u64 = 0;
 
     if op != LibcConst::EPOLL_CTL_DEL as i32 {
         let e: EpollEvent = task.CopyInObj(eventAddr)?;
@@ -233,8 +233,7 @@ pub fn SysEpollCtl(task: &mut Task, args: &SyscallArguments) -> Result<i64> {
         }
 
         mask = EventMaskFromLinux(e.Events);
-        data[0] = e.FD;
-        data[1] = e.Pad;
+        data = e.Data;
     }
 
     // Perform the requested operations.

--- a/qkernel/src/syscalls/sys_poll.rs
+++ b/qkernel/src/syscalls/sys_poll.rs
@@ -294,7 +294,7 @@ pub fn PollBlock(task: &Task, pfd: &mut [PollFd], timeout: i64) -> (Duration, Re
     let ep = EventPoll::default();
 
     for (f, (mask, _)) in waits.iter() {
-        match ep.AddEntry(task, f.clone(), 0, EventMaskFromLinux(*mask as u32), [0; 2]) {
+        match ep.AddEntry(task, f.clone(), 0, EventMaskFromLinux(*mask as u32), 0) {
             Ok(()) => (),
             Err(e) => return (timeout, Err(e)),
         }

--- a/qlib/kernel/guestfdnotifier.rs
+++ b/qlib/kernel/guestfdnotifier.rs
@@ -35,14 +35,6 @@ pub fn Notify(fd: i32, mask: EventMask) {
     GlobalIOMgr().Notify(fd, mask);
 }
 
-#[repr(C)]
-#[repr(packed)]
-#[derive(Default, Copy, Clone, Debug)]
-pub struct EpollEvent {
-    pub Event: u32,
-    pub U64: u64,
-}
-
 impl IOMgr {
     pub fn VcpuWait(&self) -> u64 {
         let ret = HostSpace::VcpuWait();
@@ -62,8 +54,8 @@ impl IOMgr {
 
     pub fn ProcessEvents(&self, events: &[EpollEvent]) {
         for e in events {
-            let fd = e.U64 as i32;
-            let event = e.Event as EventMask;
+            let fd = e.Data as i32;
+            let event = e.Events as EventMask;
             self.Notify(fd, event)
         }
     }

--- a/qlib/kernel/kernel/epoll/epoll.rs
+++ b/qlib/kernel/kernel/epoll/epoll.rs
@@ -57,7 +57,7 @@ pub struct Event {
 
     // Data is an opaque 64-bit value provided by the caller when adding the
     // entry, and returned to the caller when the entry reports an event.
-    pub Data: [i32; 2],
+    pub Data: u64,
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -71,7 +71,7 @@ pub struct Event {
     _pad: i32,
     // Data is an opaque 64-bit value provided by the caller when adding the
     // entry, and returned to the caller when the entry reports an event.
-    pub Data: [i32; 2],
+    pub Data: u64,
 }
 
 // An entry is always in one of the following lists:
@@ -227,8 +227,8 @@ impl EventPoll {
             #[cfg(target_arch = "aarch64")]
             events.Push(Event {
                 Events: ready as u32,
-                Data: entry.lock().userData,
                 _pad: 0,
+                Data: entry.lock().userData,
             });
             #[cfg(target_arch = "x86_64")]
             events.Push(Event {
@@ -311,7 +311,7 @@ impl EventPoll {
         file: File,
         flags: EntryFlags,
         mask: EventMask,
-        data: [i32; 2],
+        data: u64,
     ) -> Result<()> {
         let id = file.UniqueId();
         let fops = file.FileOp.clone();
@@ -387,7 +387,7 @@ impl EventPoll {
         file: File,
         flags: EntryFlags,
         mask: EventMask,
-        data: [i32; 2],
+        data: u64,
     ) -> Result<()> {
         let id = file.UniqueId();
         let files = self.files.lock();

--- a/qlib/kernel/kernel/epoll/epoll_entry.rs
+++ b/qlib/kernel/kernel/epoll/epoll_entry.rs
@@ -41,7 +41,7 @@ pub struct PollEntryInternal {
 
     pub id: u64,
     pub file: FileWeak,
-    pub userData: [i32; 2],
+    pub userData: u64,
     pub waiter: WaitEntryWeak,
     pub mask: EventMask,
     pub flags: EntryFlags,

--- a/qlib/kernel/quring/uring_async.rs
+++ b/qlib/kernel/quring/uring_async.rs
@@ -1541,20 +1541,12 @@ impl PollHostEpollWait {
     }
 }
 
-#[repr(C)]
-#[repr(packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct EpollEvent1 {
-    pub Events: u32,
-    pub Data: u64,
-}
-
 #[derive(Clone, Debug, Copy)]
 pub struct AsyncEpollCtl {
     pub epollfd: i32,
     pub fd: i32,
     pub op: i32,
-    pub ev: EpollEvent1,
+    pub ev: EpollEvent,
 }
 
 impl AsyncOpsTrait for AsyncEpollCtl {
@@ -1571,10 +1563,7 @@ impl AsyncEpollCtl {
             epollfd: epollfd,
             fd: fd,
             op: op,
-            ev: EpollEvent1 {
-                Events: mask,
-                Data: fd as u64,
-            },
+            ev: EpollEvent::new(mask, fd as u64)
         };
     }
 }

--- a/qlib/linux_def.rs
+++ b/qlib/linux_def.rs
@@ -264,8 +264,7 @@ pub struct LibcSysinfo {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EpollEvent {
     pub Events: u32,
-    pub FD: i32,
-    pub Pad: i32,
+    pub Data: u64,
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -273,9 +272,19 @@ pub struct EpollEvent {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EpollEvent {
     pub Events: u32,
-    pub _pad: i32,
-    pub FD: i32,
-    pub Pad: i32,
+    _pad: i32,
+    pub Data: u64,
+}
+
+impl EpollEvent {
+    #[cfg(target_arch = "x86_64")]
+    pub fn new(events: u32, data: u64) -> Self {
+        return Self {Events:events, Data:data}
+    }
+    #[cfg(target_arch = "aarch64")]
+    pub fn new(events: u32, data: u64) -> Self {
+        return Self {Events:events, _pad: 0, Data:data}
+    }
 }
 
 pub struct MRemapType {}

--- a/qvisor/src/vmspace/hostfdnotifier.rs
+++ b/qvisor/src/vmspace/hostfdnotifier.rs
@@ -21,14 +21,6 @@ use super::super::qlib::linux_def::*;
 //use super::super::qlib::qmsg::input::*;
 //use super::super::SHARE_SPACE;
 
-#[repr(C)]
-#[repr(packed)]
-#[derive(Default, Copy, Clone, Debug)]
-pub struct EpollEvent {
-    pub Event: u32,
-    pub U64: u64,
-}
-
 pub struct HostFdNotifier {
     //main epoll fd
     pub epollfd: i32,
@@ -93,8 +85,8 @@ impl HostFdNotifier {
 
         if nfds > 0 {
             for e in &events[0..nfds as usize] {
-                let fd = e.U64 as i32;
-                let event = e.Event as EventMask;
+                let fd = e.Data as i32;
+                let event = e.Events as EventMask;
                 Self::FdNotify(fd, event);
             }
         }


### PR DESCRIPTION
the userData is sometimes defined as [i32; 2] in Quark code. This doesn't make sense to me because the data is used in one piece as a u64 anyways. But I may be wrong.

However I don't see where this array is converted into u64, am I missing something? What's the initial idea of define the userData as [i32; 2] ?

This is tested on both x86 and aarch64, I don't see regression so far. Also fixes #1230 

CC @QuarkContainer 