### PR TITLE
epoll: use repr(packed) for EpollEvent

### DIFF
--- a/qlib/kernel/kernel/epoll/epoll.rs
+++ b/qlib/kernel/kernel/epoll/epoll.rs
@@ -49,6 +49,7 @@ pub unsafe fn InitSingleton() {
 // format to avoid extra copying/allocation when writing events to userspace.
 #[cfg(target_arch = "x86_64")]
 #[derive(Default, Clone, Copy, Debug)]
+#[repr(packed)]
 #[repr(C)]
 pub struct Event {
     // Events is the event mask containing the set of events that have been
@@ -62,6 +63,7 @@ pub struct Event {
 
 #[cfg(target_arch = "aarch64")]
 #[derive(Default, Clone, Copy, Debug)]
+#[repr(packed)]
 #[repr(C)]
 pub struct Event {
     // Events is the event mask containing the set of events that have been

--- a/qlib/linux_def.rs
+++ b/qlib/linux_def.rs
@@ -260,6 +260,7 @@ pub struct LibcSysinfo {
 }
 
 #[cfg(target_arch = "x86_64")]
+#[repr(packed)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EpollEvent {
@@ -268,6 +269,7 @@ pub struct EpollEvent {
 }
 
 #[cfg(target_arch = "aarch64")]
+#[repr(packed)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct EpollEvent {


### PR DESCRIPTION
otherwise it may cause alignment issue


Suggested-by: Yiliang Dong  <dongyiliangsteven@163.com>