### PR TITLE
toolchain: enable using cargo's own build-std

### DIFF
--- a/qkernel/.cargo/config.toml
+++ b/qkernel/.cargo/config.toml
@@ -1,0 +1,3 @@
+[unstable]
+build-std = ["core","alloc", "compiler_builtins"]
+build-std-features = ["compiler-builtins-mem"]

--- a/qkernel/makefile
+++ b/qkernel/makefile
@@ -25,10 +25,10 @@ $(kernel_debug): kernel_debug $(assembly_object_files)
 		$(assembly_object_files) $(qkernel_debug)
 
 kernel:
-	CARGO_TARGET_DIR=../target cargo +$(TOOLCHAIN) xbuild --target $(arch)-qkernel.json --release
+	CARGO_TARGET_DIR=../target cargo +$(TOOLCHAIN) build --target $(arch)-qkernel.json --release
 
 kernel_debug:
-	CARGO_TARGET_DIR=../target cargo +$(TOOLCHAIN) xbuild --target $(arch)-qkernel.json
+	CARGO_TARGET_DIR=../target cargo +$(TOOLCHAIN) build --target $(arch)-qkernel.json
 
 ../build/arch/$(arch)/%.o: src/qlib/kernel/arch/$(arch)/%.s
 	@mkdir -p $(shell dirname $@)


### PR DESCRIPTION
we need to build the toolchain because qkernel (arch-qkernel.json) is not one of the default targets. We have been using the cargo-xbuild tool for this and it worked fine, however it's not  under active maintance for ~ 2 years and there could be some issues with newer rust toolchain as of May, 2024.

Rust's build-std is a unstable feature that does the same thing: we tell it to build the components e.g. core, alloc, builtins ... in the .cargo/config.toml so that cargo builds them with the custom target specified by `--target xyz.json`. To use this, simply replace the `cargo xbuild` with `cargo build` in qkernel's makefile, nothing else needs to change. (this approach is also noted in cargo-xbuild's docs)

Since cargo xbuild is not breaking (yet) and the build-std is not a unstable feature (yet), I'm keeping the cargo-xbuild as default. The build-std could opt-in if needed.