### PR TITLE
fix libpq nonblocking connect readiness

### DIFF
--- a/qkernel/src/syscalls/sys_poll.rs
+++ b/qkernel/src/syscalls/sys_poll.rs
@@ -205,7 +205,7 @@ pub fn DoSelect(
             if (events & SELECT_EXCEPT_EVENTS) != 0 {
                 bitSetCount += 1;
             } else {
-                w[i] &= !m;
+                e[i] &= !m;
             }
         }
     }

--- a/qlib/kernel/socket/hostinet/uring_socket.rs
+++ b/qlib/kernel/socket/hostinet/uring_socket.rs
@@ -1148,6 +1148,25 @@ impl SockOperations for UringSocketOperations {
                         return Err(Error::SysError(SysErr::EINVAL));
                     }
 
+                    if self.ConnErrno() == -SysErr::EINPROGRESS {
+                        let mut hostErrno = Box::new_in(0i32, GUEST_HOST_SHARED_ALLOCATOR);
+                        let mut hostLen = Box::new_in(4i32, GUEST_HOST_SHARED_ALLOCATOR);
+                        let res = Kernel::HostSpace::GetSockOpt(
+                            self.fd,
+                            level,
+                            name,
+                            &mut *hostErrno as *mut i32 as u64,
+                            &mut *hostLen as *mut i32 as u64,
+                        );
+                        if res < 0 {
+                            return Err(Error::SysError(-res as i32));
+                        }
+                        if *hostErrno == 0 {
+                            self.SetConnErrno(0);
+                            self.PostConnect();
+                        }
+                    }
+
                     if self.ConnErrno() != 0 {
                         let errno = self.ConnErrno();
                         self.SetConnErrno(0);


### PR DESCRIPTION
## Summary

Fix two TCP readiness issues that break libpq/psycopg's nonblocking connect path under Quark:

- Clear the select(2) exception fdset entry itself when no exception event occurred.
- When uring TCP `getsockopt(SO_ERROR)` only has cached `EINPROGRESS`, ask the host socket for the current `SO_ERROR`; if the host reports success, clear the cached state and promote the socket through `PostConnect()`.

## Root cause

psycopg/libpq opens the TCP socket nonblocking, receives `EINPROGRESS` from `connect(2)`, and then immediately checks `getsockopt(SO_ERROR)` before sending the PostgreSQL startup packet. Quark was still returning cached `EINPROGRESS` until a later readiness path advanced the uring socket state.

A separate select fdset typo caused sockets to appear in the exception fdset even after `SO_ERROR` was clear.

## Validation

Validated through Tinyhost's real droplet e2e against `postgres:16-alpine`:

```text
SOCKET connect_ex=115 immediate_so_error=0 select_read=False select_write=True select_except=False so_error=0
RESULT quark/socket PASS
RESULT quark/pg8000 PASS
RESULT quark/psycopg PASS
root=clear; quark libpq nonblocking connect works against real Postgres
62_QUARK_PSYCOPG_OK
```
